### PR TITLE
fix component rideable always in components

### DIFF
--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentRideable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentRideable.kt
@@ -37,7 +37,9 @@ class ComponentRideable : MonsteraFile {
                 }
             }
 
-            general["seats"] = seats.getData()
+            val seatsData = seats.getData()
+            if(seatsData.isNotEmpty())
+                general["seats"] = seatsData
 
             return general
         }

--- a/src/test/kotlin/com/lop/devtools/monstera/files/ComponentTest.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/files/ComponentTest.kt
@@ -1,0 +1,43 @@
+package com.lop.devtools.monstera.files
+
+import com.google.gson.GsonBuilder
+import com.lop.devtools.monstera.files.beh.entitiy.BehEntity
+import org.skyscreamer.jsonassert.JSONAssert
+import kotlin.test.Test
+
+class ComponentTest {
+    @Test
+    fun basicEntityTest() {
+        val entity = BehEntity()
+        with(entity) {
+            description {
+                identifier = "test"
+                isSpawnable = false
+                isSummonable = false
+                isExperimental = false
+            }
+            components {
+                physics {
+                    hasGravity = false
+                }
+            }
+        }
+
+        val target = mutableMapOf(
+            "description" to mutableMapOf(
+                "identifier" to "test",
+                "is_spawnable" to false,
+                "is_summonable" to false,
+                "is_experimental" to false
+            ),
+            "components" to mutableMapOf(
+                "minecraft:physics" to mutableMapOf(
+                    "has_gravity" to false
+                )
+            )
+        )
+
+        val gson = GsonBuilder().setPrettyPrinting().create()
+        JSONAssert.assertEquals(gson.toJson(target), gson.toJson(entity.unsafe.getData()), false)
+    }
+}


### PR DESCRIPTION
## Bug Fix

closes #6 

fixes as described in #6 the issue that the component "rideable" is always added into the entity component list

## Test

Added test to check if the component is still within the component list