### PR TITLE
Fix logger name includes entity name more reliable

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -11,7 +11,7 @@ assignees: ''
 A clear and concise description of what the bug is.
 
 **Version**
-Monster: [Monstera Version]
+Monstera: [Monstera Version]
 Minecraft: [Minecraft Version]
 
 **To Reproduce**

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/BasicAddon.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/BasicAddon.kt
@@ -1,6 +1,8 @@
 package com.lop.devtools.monstera.addon
 
 import com.lop.devtools.monstera.Config
+import com.lop.devtools.monstera.getMonsteraLogger
+import kotlin.system.measureTimeMillis
 
 @DslMarker
 annotation class AddonEntry
@@ -14,7 +16,12 @@ class BasicAddon(config: Config) : AddonImpl(config) {
 
 @AddonEntry
 fun addon(config: Config, addon: Addon.() -> Unit): Config {
-    BasicAddon(config).apply(addon).build()
+    val logger = getMonsteraLogger("Monstera")
+    logger.info("Building Addon ...")
+    val buildTime = measureTimeMillis {
+        BasicAddon(config).apply(addon).build()
+    }
+    logger.info("Finished building Addon in ${buildTime / 1000}.${buildTime % 1000}s")
     return config
 }
 

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/entity/EnitityUtils.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/entity/EnitityUtils.kt
@@ -10,7 +10,7 @@ import kotlin.math.abs
  * return the geometry id from a given json file, empty if parser failed
  */
 fun getGeoId(file: File): String {
-    val logger = getMonsteraLogger("Geometry")
+    fun logger() = getMonsteraLogger("Geometry")
     val jsonString = file.readText()
     val geoFile = Gson().fromJson(jsonString, JsonObject::class.java)
 
@@ -36,7 +36,7 @@ fun getGeoId(file: File): String {
             }
         }
     } catch (e: Exception) {
-        logger.error("No geometry identifier found in file: ${file.name}!")
+        logger().error("No geometry identifier found in file: ${file.name}!")
     }
     return ""
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/entity/behaviour/BehaviourEntityImpl.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/entity/behaviour/BehaviourEntityImpl.kt
@@ -18,7 +18,7 @@ import com.lop.devtools.monstera.getMonsteraLogger
 abstract class BehaviourEntityImpl(
     override val unsafeParent: Entity
 ) : BehaviourEntity, OverwriteComponentsImpl(unsafeParent) {
-    private val logger = getMonsteraLogger("Behaviour")
+    private fun logger() = getMonsteraLogger("Behaviour")
 
     override var runtimeIdentifier: RuntimeIdentifier? = null
         set(value) {
@@ -38,7 +38,7 @@ abstract class BehaviourEntityImpl(
             description {
                 animations {
                     if (unsafe.general.containsKey(name)) {
-                        logger.warn(
+                        logger().warn(
                             "(${unsafeParent.name}) Animation '${
                                 name.split(".").last()
                             }' already exists (overwriting)"
@@ -68,7 +68,7 @@ abstract class BehaviourEntityImpl(
                 }
                 animations {
                     if (unsafe.general.containsKey(name)) {
-                        logger.warn(
+                        logger().warn(
                             "(${unsafeParent.name})" + "Animation '${
                                 name.split(".").last()
                             }' already exists (overwriting)"

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/entity/resource/ResourceEntityImpl.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/entity/resource/ResourceEntityImpl.kt
@@ -16,7 +16,7 @@ abstract class ResourceEntityImpl(override val unsafeParent: Entity) : ResourceE
     override var disableRender: Boolean = false
     val renderParts: ArrayList<BasicRenderPart> = ArrayList()
     override var hasDefaultTexture = false
-    private val logger = getMonsteraLogger("Resource")
+    private fun logger() = getMonsteraLogger("Resource")
 
 
     override fun textureLayer(texturePath: String, layerName: String) {
@@ -166,7 +166,7 @@ abstract class ResourceEntityImpl(override val unsafeParent: Entity) : ResourceE
     override fun animation(file: File) {
         val animations = extractAnimationIdsFromFile(file)
         if (animations.isEmpty()) {
-            logger.warn("No animations found in file: ${file.name}")
+            logger().warn("No animations found in file: ${file.name}")
             return
         }
         val uniqueFilename = getUniqueFileName(file)

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/sound/SoundData.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/sound/SoundData.kt
@@ -6,12 +6,12 @@ import com.lop.devtools.monstera.getMonsteraLogger
 import java.io.File
 
 class SoundData(val addon: Addon) : Sound {
-    private val logger = getMonsteraLogger("Sound")
+    private fun logger() = getMonsteraLogger("Sound")
 
     override var identifier: String = ""
         set(value) {
             if (value.contains(":")) {
-                logger.warn("($identifier) Sound identifier should not contain a ':', follow the naming convention" +
+                logger().warn("($identifier) Sound identifier should not contain a ':', follow the naming convention" +
                         " '<projectShort>.<entity>.<sound>' like 'tp.test.drive'")
             }
             field = value

--- a/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimStateComponent.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimStateComponent.kt
@@ -7,7 +7,7 @@ import com.lop.devtools.monstera.getMonsteraLogger
 
 @Suppress("MemberVisibilityCanBePrivate", "unused")
 class AnimStateComponent: MonsteraFile {
-    private val logger = getMonsteraLogger("AnimController State")
+    private fun logger() = getMonsteraLogger("AnimController State")
     /**
      * unsafe to use variables, used for plugins/ libraries
      */
@@ -35,13 +35,13 @@ class AnimStateComponent: MonsteraFile {
 
             onEntry?.forEach {
                 if (!it.startsWith("@") && !it.startsWith("/") && !it.endsWith(";")) {
-                    logger.warn("Found onEntry Command/Event without correct prefix: '$it'," +
+                    logger().warn("Found onEntry Command/Event without correct prefix: '$it'," +
                             " expected: '@$it' or '/$it'")
                 }
             }
             onExit?.forEach {
                 if (!it.startsWith("@") && !it.startsWith("/") && !it.endsWith(";")) {
-                    logger.warn("Found onExit Command/Event without correct prefix: '$it'," +
+                    logger().warn("Found onExit Command/Event without correct prefix: '$it'," +
                             " expected: '@$it' or '/$it'")
                 }
             }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
@@ -13,7 +13,7 @@ import java.nio.file.Path
  * Create an Entity with a description, componentGroups, components and events
  */
 class BehEntity: MonsteraFile {
-    private val logger = getMonsteraLogger("BehEntity File")
+    private fun logger() = getMonsteraLogger("BehEntity File")
     override val unsafe = Unsafe()
 
     inner class Unsafe: MonsteraUnsafeMap {
@@ -39,13 +39,13 @@ class BehEntity: MonsteraFile {
             //check if there are events with no matching group
             events.unsafe.debugAddedGroups.forEach {
                 if (!groupsData.keys.contains(it)) {
-                    logger.warn("ComponentGroup '$it' was added in a event but does not exist")
+                    logger().warn("ComponentGroup '$it' was added in a event but does not exist")
                 }
             }
             //check if there are groups that were not added
             groupsData.keys.forEach {
                 if (!events.unsafe.debugAddedGroups.contains(it)) {
-                    logger.warn("ComponentGroup '$it' was never added with events")
+                    logger().warn("ComponentGroup '$it' was never added with events")
                 }
             }
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntityComponents.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntityComponents.kt
@@ -313,6 +313,10 @@ class BehEntityComponents : MonsteraFile {
      *
      * lets the entity circle around its target
      * used by the phantom
+     *
+     * note: if the entity has no target, the heightAboveTargetRange is the world level.
+     * So if the heightAboveTargetRange is set to 20, the entity will literally go to y = 20 and circly there
+     *
      * @sample circleAroundAnchorSample
      */
     fun circleAroundAnchor(value: ComponentCircleAroundAnchor.() -> Unit) {

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentAttackDamage.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentAttackDamage.kt
@@ -6,14 +6,14 @@ import com.lop.devtools.monstera.getMonsteraLogger
 
 class ComponentAttackDamage : MonsteraFile {
     override val unsafe = Unsafe()
-    private val logger = getMonsteraLogger("Component Attack Damage")
+    private fun logger() = getMonsteraLogger("Component Attack Damage")
 
     inner class Unsafe : MonsteraUnsafeMap {
         val general = mutableMapOf<String, Any>()
 
         override fun getData(): MutableMap<String, Any> {
             if (!iKnowWhatImDoing)
-                logger.warn("You probably mean attack { } not attackDamage { }. set 'iKnowWhatImDoing = true' to remove this warning!")
+                logger().warn("You probably mean attack { } not attackDamage { }. set 'iKnowWhatImDoing = true' to remove this warning!")
             value?.let { general["value"] = it }
             return general
         }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentEntitySensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentEntitySensor.kt
@@ -5,7 +5,7 @@ import com.lop.devtools.monstera.getMonsteraLogger
 
 class ComponentEntitySensor {
     val general = mutableMapOf<String, Any>()
-    private val logger = getMonsteraLogger("Component Entity Sensor")
+    private fun logger() = getMonsteraLogger("Component Entity Sensor")
 
     var sensorRange: Float? = null
     var relativeRange: Boolean? = null
@@ -25,12 +25,12 @@ class ComponentEntitySensor {
         minimumCount?.let {
             general["minimum_count"] = it
             if (it == 0)
-                logger.warn("minimumCount cant be 0 as the sensor can't check this -> work with inverse filters!")
+                logger().warn("minimumCount cant be 0 as the sensor can't check this -> work with inverse filters!")
         }
         maximumCount?.let {
             general["maximum_count"] = it
             if (it == 0)
-                logger.warn("minimumCount cant be 0 as the sensor can't check this -> work with inverse filters!")
+                logger().warn("minimumCount cant be 0 as the sensor can't check this -> work with inverse filters!")
         }
         event?.let { general["event"] = it }
         return general

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentRideable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentRideable.kt
@@ -7,7 +7,7 @@ import com.lop.devtools.monstera.getMonsteraLogger
 
 class ComponentRideable : MonsteraFile {
     override val unsafe = Unsafe()
-    private val logger = getMonsteraLogger("Component Ride")
+    private fun logger() = getMonsteraLogger("Component Ride")
 
     inner class Unsafe : MonsteraUnsafeMap {
         val general = mutableMapOf<String, Any>()
@@ -26,13 +26,13 @@ class ComponentRideable : MonsteraFile {
                 //stream of all entries matched if player is present -> if so only execute warnings once
                 types.firstOrNull { it == "player" }?.apply {
                     if (!general.containsKey("interact_text") && !ignoreInteractText) {
-                        logger.warn(
+                        logger().warn(
                             "no interact text found: Players with touch screen can't interact, add " +
                                     "interactText() to you're rideable component or ignore it with ignoreInteractText()"
                         )
                     }
                     if (!ignoreExitText && !setExitText) {
-                        logger.warn("no exit text found: Players may not know how to leave the current entity")
+                        logger().warn("no exit text found: Players may not know how to leave the current entity")
                     }
                 }
             }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/properties/EntityProperties.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/properties/EntityProperties.kt
@@ -8,7 +8,7 @@ import com.lop.devtools.monstera.getMonsteraLogger
 
 class EntityProperties : MonsteraFile {
     override val unsafe = Unsafe()
-    private val logger = getMonsteraLogger("Property")
+    private fun logger() = getMonsteraLogger("Property")
 
     inner class Unsafe : MonsteraUnsafeMap {
         val general = mutableMapOf<String, GenericProperty<*>>()
@@ -16,7 +16,7 @@ class EntityProperties : MonsteraFile {
             v as MonsteraFile
             val dataMap = (v.unsafe as MonsteraUnsafeMap).getData()
             if(!dataMap.containsKey("default")) {
-                logger.warn("No default value for property given!")
+                logger().warn("No default value for property given!")
             }
             k to dataMap
         }.toMap().toMutableMap()
@@ -40,7 +40,7 @@ class EntityProperties : MonsteraFile {
                 (unsafe.general[name] as EnumProperty).apply(propertyData)
                 return
             }
-            logger.warn("Property '$name' is defined twice with a different Type! (Overwriting)")
+            logger().warn("Property '$name' is defined twice with a different Type! (Overwriting)")
         }
         unsafe.general[idWithNameSpace(name)] = EnumProperty().apply(propertyData)
     }
@@ -62,7 +62,7 @@ class EntityProperties : MonsteraFile {
                 (unsafe.general[name] as BoolProperty).apply(propertyData)
                 return
             }
-            logger.warn("Property '$name' is defined twice with a different Type! (Overwriting)")
+            logger().warn("Property '$name' is defined twice with a different Type! (Overwriting)")
         }
         unsafe.general[idWithNameSpace(name)] = BoolProperty().apply(propertyData)
     }
@@ -85,7 +85,7 @@ class EntityProperties : MonsteraFile {
                 (unsafe.general[name] as IntProperty).apply(propertyData)
                 return
             }
-            logger.warn("Property '$name' is defined twice with a different Type! (Overwriting)")
+            logger().warn("Property '$name' is defined twice with a different Type! (Overwriting)")
         }
         unsafe.general[idWithNameSpace(name)] = IntProperty().apply(propertyData)
     }
@@ -108,7 +108,7 @@ class EntityProperties : MonsteraFile {
                 (unsafe.general[name] as FloatProperty).apply(propertyData)
                 return
             }
-            logger.warn("Property '$name' is defined twice with a different Type! (Overwriting)")
+            logger().warn("Property '$name' is defined twice with a different Type! (Overwriting)")
         }
         unsafe.general[idWithNameSpace(name)] = FloatProperty().apply(propertyData)
     }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/properties/types/EnumProperty.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/properties/types/EnumProperty.kt
@@ -8,7 +8,7 @@ import org.slf4j.LoggerFactory
 
 @Suppress("MemberVisibilityCanBePrivate")
 class EnumProperty: GenericProperty<String>, MonsteraFile {
-    private val logger = getMonsteraLogger("Enum Property")
+    private fun logger() = getMonsteraLogger("Enum Property")
 
     override val unsafe = Unsafe()
     inner class Unsafe: MonsteraUnsafeMap {
@@ -16,14 +16,14 @@ class EnumProperty: GenericProperty<String>, MonsteraFile {
 
         override fun getData(): MutableMap<String, Any> {
             if (values.size > 16)
-                logger.warn("max entries for enum values is 16!")
+                logger().warn("max entries for enum values is 16!")
             if(values.isEmpty())
-                logger.warn("entries are empty, enum property will be ignored!")
+                logger().warn("entries are empty, enum property will be ignored!")
             values.filter { it.length > 32 || it.isEmpty() }.forEach {
-                logger.warn("entry '$it' is invalid, length must be between 1 and 32, length was ${it.length}!")
+                logger().warn("entry '$it' is invalid, length must be between 1 and 32, length was ${it.length}!")
             }
             values.filter { !it.first().isLetter() }.forEach {
-                logger.warn("entry '$it' is invalid, must start with a alphabetic character found '${it.first()}'!")
+                logger().warn("entry '$it' is invalid, must start with a alphabetic character found '${it.first()}'!")
             }
             general["type"] = "enum"
             general["values"] = values

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/materials/Materials.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/materials/Materials.kt
@@ -23,7 +23,7 @@ interface MaterialExtensions {
 
 class Materials(val fileName: String) : MonsteraFile, MaterialExtensions {
     override val unsafe = Unsafe()
-    private val logger = getMonsteraLogger("Material")
+    private fun logger() = getMonsteraLogger("Material")
 
     companion object {
         private val instances = mutableMapOf<Int, Materials>()
@@ -43,7 +43,7 @@ class Materials(val fileName: String) : MonsteraFile, MaterialExtensions {
         override fun getData(): MutableMap<String, Any> {
             general.putAll(materialDefs.map { (id, material) -> id to material.unsafe.getData() })
             if (!general.containsKey("version")) {
-                logger.error("Build failed, no version found, materials won't be applied!")
+                logger().error("Build failed, no version found, materials won't be applied!")
             }
             return mutableMapOf("materials" to general)
         }
@@ -67,7 +67,7 @@ class Materials(val fileName: String) : MonsteraFile, MaterialExtensions {
      */
     fun newMaterial(material: Material, data: MaterialsDef.() -> Unit): String {
         if (unsafe.materialDefs.containsKey(material.name)) {
-            unsafe.materialDefs[material.name]?.apply(data) ?: logger.error(
+            unsafe.materialDefs[material.name]?.apply(data) ?: logger().error(
                 "Invalid state. This should not happen! Material list contained key '$material' but when trying to apply data it was null!"
             )
         } else {

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenConUvAnim.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenConUvAnim.kt
@@ -7,7 +7,7 @@ import com.lop.devtools.monstera.getMonsteraLogger
 
 class ResRenConUvAnim : MonsteraFile {
     override val unsafe = Unsafe()
-    private val logger = getMonsteraLogger("Uv Render")
+    private fun logger() = getMonsteraLogger("Uv Render")
 
     inner class Unsafe : MonsteraUnsafeMap {
         val general = mutableMapOf<String, Any>()
@@ -24,7 +24,7 @@ class ResRenConUvAnim : MonsteraFile {
             is Number -> ls.add(from)
             is String -> ls.add(from)
 
-            else -> logger.warn(
+            else -> logger().warn(
                 "type can't be parsed: invalid type '${from::class.java.name}'"
             )
         }
@@ -33,7 +33,7 @@ class ResRenConUvAnim : MonsteraFile {
             is Number -> ls.add(to)
             is String -> ls.add(to)
 
-            else -> logger.warn(
+            else -> logger().warn(
                 "type can't be parsed: '${to::class.java.name}'"
             )
         }


### PR DESCRIPTION
## Fix entity names in logger

closes #8 

Entity names are now included in the logger name for more ambiguous class creations, so the logger name is evaluated each time the logger is called.

## Analytics

Added basic time tracking of how long the addon took to build