### PR TITLE
Monstera allow local config

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,3 +7,4 @@
 * [Items](./pages/Items.md)
 * [Molang](./pages/Molang.md)
 * [Sounds](./pages/Sounds.md)
+* [Marketplace](./pages/Marketplace.md)

--- a/docs/pages/Marketplace.md
+++ b/docs/pages/Marketplace.md
@@ -1,0 +1,25 @@
+# Marketplace
+
+This page is not finished!
+
+## Formatting
+
+Monstera tries to remain Marketplace compliant by default, but there are some places where a developer has to configure
+things themselves.
+
+### Addons
+
+For addons, Marketplace teams must place entities, blocks or other files in their own subfolders to prevent collisions
+with files from other Marketplace teams. You can customize all paths in the monstera.json file for this purpose. For
+example:
+"behEntity": "entities" -> "behEntity": "entities/partner_name"
+
+### Other
+
+Collisions with other add-ons are not normally a problem, as you can assume that the developed add-on is the only one
+that is active.
+
+## Packaging
+
+It is possible to create a zip file using the standard library that is Marketplace compatible. This can still be complex
+under certain circumstances, but has the advantage of benefiting from a version control system (such as Git).

--- a/src/main/kotlin/com/lop/devtools/monstera/Config.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/Config.kt
@@ -80,6 +80,7 @@ fun loadConfig(
             resUUID = UUID.fromString(monsteraConfig.resUUID),
             resModUUID = UUID.fromString(monsteraConfig.resModuleUUID),
             targetMcVersion = monsteraConfig.targetMcVersion,
+            hashFileNames = monsteraConfig.hashFileNames,
             behPath = behPath,
             resPath = resPath,
 
@@ -164,6 +165,7 @@ class MonsteraConfig(
     var scriptingVersion: String,
     var scriptEntryFile: String?,
     var packIcon: String?,
+    var hashFileNames: Boolean = false,
     var minecraftPaths: MinecraftAddonPaths,
     var minecraftFormatVersions: MinecraftFormatVersions,
 )
@@ -249,7 +251,8 @@ class Config(
     var formatVersions: FormatVersions = FormatVersions(getVersionAsString(targetMcVersion)),
     var langFileBuilder: AddonLangFileBuilders = AddonLangFileBuilders(behPath, resPath),
     var scriptEntryFile: File = File(),
-    var scriptingVersion: String = "1.8.0"
+    var scriptingVersion: String = "1.8.0",
+    var hashFileNames: Boolean = false
 ) {
     init {
         behPath.toFile().deleteRecursively()

--- a/src/main/kotlin/com/lop/devtools/monstera/Config.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/Config.kt
@@ -2,6 +2,7 @@
 
 package com.lop.devtools.monstera
 
+import com.google.gson.Gson
 import com.lop.devtools.monstera.addon.dev.ResourceLoader
 import com.lop.devtools.monstera.addon.entity.resource.copyDefaultTextureTo
 import com.lop.devtools.monstera.addon.entity.resource.generateDefaultGeo
@@ -18,9 +19,191 @@ import kotlin.io.path.Path
 annotation class ConfigDSL
 
 @ConfigDSL
+@Deprecated("Use a config file, this function does not correcly apply config data!",
+    ReplaceWith("loadConfig()", "com.lop.devtools.monstera.Config")
+)
 fun config(projectName: String, data: Config.() -> Unit): Config {
     return Config(projectName).apply(data)
 }
+
+@ConfigDSL
+fun loadConfig(
+    conf: String = "${System.getProperty("user.dir")}/monstera.json",
+    local: String = "${System.getProperty("user.dir")}/monstera-local.json"
+) = loadConfig(File(conf), File(local))
+
+@ConfigDSL
+fun loadConfig(
+    conf: File,
+    local: File
+): Result<Config> {
+    if (!conf.exists() || !local.exists()) {
+        return Result.failure(Error("Could not find config file!"))
+    }
+
+    try {
+        val gson = Gson()
+        val monsteraConfig: MonsteraConfig = gson.fromJson(conf.readText(), MonsteraConfig::class.java)
+        val monsteraLocalConfig: MonsteraLocalConfig =
+            gson.fromJson(local.readText(), MonsteraLocalConfig::class.java)
+
+        val behPath = Path(
+            System.getProperty("user.dir"),
+            monsteraLocalConfig.buildPath,
+            "development_behavior_packs",
+            monsteraConfig.projectShort.uppercase() + "_BP"
+        )
+        val resPath = Path(
+            System.getProperty("user.dir"),
+            monsteraLocalConfig.buildPath,
+            "development_resource_packs",
+            monsteraConfig.projectShort.uppercase() + "_BP"
+        )
+
+        val config = Config(
+            projectName = monsteraConfig.name,
+            namespace = monsteraConfig.namespace,
+            projectShort = monsteraConfig.projectShort,
+            description = monsteraConfig.description,
+            version = monsteraConfig.version,
+            authors = monsteraConfig.authors,
+            worldUUID = UUID.fromString(monsteraConfig.worldUUID),
+            worldModuleUUID = UUID.fromString(monsteraConfig.worldModuleUUID),
+            behUUID = UUID.fromString(monsteraConfig.behUUID),
+            behModUUID = UUID.fromString(monsteraConfig.behModuleUUID),
+            behScriptUUID = UUID.fromString(monsteraConfig.scriptUUID),
+            resUUID = UUID.fromString(monsteraConfig.resUUID),
+            resModUUID = UUID.fromString(monsteraConfig.resModuleUUID),
+            targetMcVersion = monsteraConfig.targetMcVersion,
+            behPath = behPath,
+            resPath = resPath,
+
+            comMojangPath = monsteraLocalConfig.minecraftDir?.let { Path(it) }
+                ?: Path(
+                    System.getenv("LOCALAPPDATA") ?: "",
+                    "Packages",
+                    "Microsoft.MinecraftUWP_8wekyb3d8bbwe",
+                    "LocalState",
+                    "games",
+                    "com.mojang"
+                ),
+            paths = Config.AddonPaths(
+                behBase = behPath,
+                resBase = resPath,
+                behEntity = behPath.resolve(monsteraConfig.minecraftPaths.behEntity),
+                behAnimController = behPath.resolve(monsteraConfig.minecraftPaths.behAnimController),
+                behAnim = behPath.resolve(monsteraConfig.minecraftPaths.behAnim),
+                behRecipe = behPath.resolve(monsteraConfig.minecraftPaths.behRecipes),
+                behBlocks = behPath.resolve(monsteraConfig.minecraftPaths.behBlocks),
+                behItems = behPath.resolve(monsteraConfig.minecraftPaths.behItems),
+                behSpawnRules = behPath.resolve(monsteraConfig.minecraftPaths.behSpawnRules),
+                behTrading = behPath.resolve(monsteraConfig.minecraftPaths.behTrading),
+                behTexts = behPath.resolve(monsteraConfig.minecraftPaths.behTexts),
+                behScripts = behPath.resolve(monsteraConfig.minecraftPaths.behScripts),
+                behMcFunction = behPath.resolve(monsteraConfig.minecraftPaths.behMcFunction),
+                resAnim = resPath.resolve(monsteraConfig.minecraftPaths.resAnim),
+                resItem = resPath.resolve(monsteraConfig.minecraftPaths.resItem),
+                resModels = resPath.resolve(monsteraConfig.minecraftPaths.resModels),
+                resMaterials = resPath.resolve(monsteraConfig.minecraftPaths.resMaterials),
+                resParticles = resPath.resolve(monsteraConfig.minecraftPaths.resParticles),
+                resRenderControllers = resPath.resolve(monsteraConfig.minecraftPaths.resRenderControllers),
+                resSounds = resPath.resolve(monsteraConfig.minecraftPaths.resSounds),
+                resTextures = resPath.resolve(monsteraConfig.minecraftPaths.resTextures),
+                resAttachable = resPath.resolve(monsteraConfig.minecraftPaths.resAttachable),
+                resTexts = resPath.resolve(monsteraConfig.minecraftPaths.resTexts),
+            ),
+            formatVersions = Config.FormatVersions(
+                getVersionAsString(monsteraConfig.targetMcVersion),
+                behEntity = monsteraConfig.minecraftFormatVersions.behEntitty,
+                resEntity = monsteraConfig.minecraftFormatVersions.resEntity,
+                resItem = monsteraConfig.minecraftFormatVersions.resItem,
+                behItem = monsteraConfig.minecraftFormatVersions.behItem,
+                behAnimation = monsteraConfig.minecraftFormatVersions.behAnim,
+                behBlock = monsteraConfig.minecraftFormatVersions.behBlock,
+                behRecipe = monsteraConfig.minecraftFormatVersions.behRecipe,
+                behSpawnRules = monsteraConfig.minecraftFormatVersions.behSpawnRule,
+                behAnimController = monsteraConfig.minecraftFormatVersions.behAnimController,
+                resAnimController = monsteraConfig.minecraftFormatVersions.resAnimController,
+                resAttachable = monsteraConfig.minecraftFormatVersions.resAttachable,
+                resSoundDefs = monsteraConfig.minecraftFormatVersions.resSoundDefs,
+                resRendercontroller = monsteraConfig.minecraftFormatVersions.resRenderController,
+            )
+        )
+        return Result.success(config)
+    } catch (e: Exception) {
+        return Result.failure(e)
+    }
+}
+
+class MonsteraConfig(
+    var name: String,
+    var projectShort: String,
+    var description: String,
+    var namespace: String,
+    var version: MutableList<Int>,
+    var authors: MutableList<String>,
+    var worldUUID: String,
+    var worldModuleUUID: String,
+    var behUUID: String,
+    var behModuleUUID: String,
+    var scriptUUID: String,
+    var resUUID: String,
+    var resModuleUUID: String,
+    var targetMcVersion: MutableList<Int>,
+    var scriptingVersion: String,
+    var minecraftPaths: MinecraftAddonPaths,
+    var minecraftFormatVersions: MinecraftFormatVersions,
+)
+
+class MinecraftAddonPaths(
+    var behEntity: String,
+    var behAnimController: String,
+    var behAnim: String,
+    var behBlocks: String,
+    var behItems: String,
+    var lootTableEntity: String,
+    var lootTableBlock: String,
+    var behSpawnRules: String,
+    var behTrading: String,
+    var behRecipes: String,
+    var behTexts: String,
+    var behScripts: String,
+    var behMcFunction: String,
+    var resAnim: String,
+    var resAnimController: String,
+    var resEntity: String,
+    var resItem: String,
+    var resModels: String,
+    var resMaterials: String,
+    var resParticles: String,
+    var resRenderControllers: String,
+    var resSounds: String,
+    var resTextures: String,
+    var resAttachable: String,
+    var resTexts: String,
+)
+
+class MinecraftFormatVersions(
+    var behEntitty: String,
+    var behItem: String,
+    var behAnim: String,
+    var behBlock: String,
+    var behRecipe: String,
+    var behSpawnRule: String,
+    var behAnimController: String,
+    var resEntity: String,
+    var resItem: String,
+    var resAnimController: String,
+    var resAttachable: String,
+    var resSoundDefs: String,
+    var resRenderController: String,
+)
+
+class MonsteraLocalConfig(
+    var projectPath: String?,
+    var buildPath: String,
+    var minecraftDir: String?
+)
 
 class Config(
     val projectName: String,
@@ -49,7 +232,7 @@ class Config(
         "com.mojang"
     ),
     var paths: AddonPaths = AddonPaths(behPath, resPath),
-    var targetMcVersion: ArrayList<Int> = arrayListOf(1, 20, 70),
+    var targetMcVersion: MutableList<Int> = arrayListOf(1, 20, 70),
     var formatVersions: FormatVersions = FormatVersions(getVersionAsString(targetMcVersion)),
     var langFileBuilder: AddonLangFileBuilders = AddonLangFileBuilders(behPath, resPath),
     var scriptEntryFile: File = File(),
@@ -151,4 +334,3 @@ class Config(
         var resRendercontroller: String = "1.10.0"
     )
 }
-

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/Addon.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/Addon.kt
@@ -62,7 +62,7 @@ open class Addon(val config: Config) {
     var buildTextureList: Boolean = true
     var buildItemTextureIndex: Boolean = true
     var buildToMcFolder: Boolean = true
-    var manifestMinEnginVersion: ArrayList<Int> = config.targetMcVersion
+    var manifestMinEnginVersion: ArrayList<Int> = ArrayList(config.targetMcVersion)
 
     var includeInfoMcFunction: Boolean = true
 
@@ -283,7 +283,7 @@ open class Addon(val config: Config) {
         generateManifest(
             config.version,
             config,
-            minEnginVersion = manifestMinEnginVersion,
+            minEnginVersion = ArrayList(manifestMinEnginVersion),
             scriptEntryFile = config.scriptEntryFile
         )
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/KotlinUtil.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/KotlinUtil.kt
@@ -1,5 +1,6 @@
 package com.lop.devtools.monstera.files
 
+import com.lop.devtools.monstera.addon.Addon
 import java.io.File
 import java.io.FileNotFoundException
 import java.nio.ByteBuffer
@@ -61,6 +62,35 @@ fun getUniqueFileName(file: File): String {
         .replace("+", "")
         .replace("/", "")
     return enc + "_" + file.name
+}
+
+fun sanetiseFilename(filename: String, fileSuffix: String): String {
+    var sanFile = filename
+        .removeSuffix(".$fileSuffix")
+        .replace("-", "_")
+        .replace(" ", "_")
+    if(Addon.active?.config?.hashFileNames == true) {
+        sanFile = getUniqueBuildFileName(Addon.active!!.config.namespace, sanFile)
+    }
+    return "${sanFile}.$fileSuffix"
+}
+
+/**
+ * create a hash out of the namespace and fileName and append it to the fileName
+ * @param namespace the namespace of the project
+ * @param filename the file name to make unique
+ * @return a unique fileName to the namespace and fileName, this might be required if multiple addons are loaded with diffrent namespaces but same file names
+ */
+fun getUniqueBuildFileName(namespace: String, filename: String): String {
+    val hash = namespace.hashCode() + filename.hashCode()
+    val buff = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(hash).array()
+    val enc = Base64
+        .getEncoder()
+        .encodeToString(buff)
+        .replace("=", "")
+        .replace("+", "")
+        .replace("/", "")
+    return "${filename}_$enc"
 }
 
 fun File(vararg parents: String): File {

--- a/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimationControllers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimationControllers.kt
@@ -9,11 +9,10 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.addon.api.MonsteraExperimental
 import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.addon.molang.Query
-import com.lop.devtools.monstera.addon.molang.Variable
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
-import java.lang.Error
 import java.nio.file.Path
 
 class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
@@ -21,14 +20,10 @@ class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
         if(animationControllersData.isEmpty())
             return Result.failure(Error("Animation Controller Data is empty, building does nothing!"))
 
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         if(path == null)
             error("path may not be null! can't build anim controller when not clear if beh or res.")
 
-        val target = MonsteraBuilder.buildTo(path, "$sanFile.json", this)
+        val target = MonsteraBuilder.buildTo(path, sanetiseFilename(filename, "json"), this)
         return Result.success(target)
     }
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimations.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimations.kt
@@ -7,24 +7,21 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
 
 class BehAnimations : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         version?.let { formatVersion = it }
 
         val buildPath = path ?: Addon.active?.config?.paths?.behAnim ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for animation file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for animation file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for animation file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for animation file '$filename' as no addon was initialized!"))
         }
 
-        val target = MonsteraBuilder.buildTo(buildPath, "$sanFile.json", this)
+        val target = MonsteraBuilder.buildTo(buildPath, sanetiseFilename(filename, "json"), this)
         return Result.success(target)
     }
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/blocks/BehBlocks.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/blocks/BehBlocks.kt
@@ -12,23 +12,20 @@ import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.blocks.components.BlockComponents
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
 class BehBlocks : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behBlocks ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for block file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for block file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behBlock ?: "1.20.50",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
@@ -15,6 +15,7 @@ import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.description.BehEntityDescription
 import com.lop.devtools.monstera.files.beh.entitiy.events.BehEntityEvent
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -48,18 +49,14 @@ class BehEntity : MonsteraBuildableFile {
         @MonsteraBuildSetter set
 
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behEntity ?: run {
-            logger().error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!"))
+            logger().error("Could not Resolve a path for entity file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for entity file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behEntity ?: "1.20.50",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItem.kt
@@ -11,24 +11,21 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
 
 class BehItem : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behItems ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for item file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for item file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for item file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for item file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behItem ?: "1.50.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/recipes/BehRecipe.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/recipes/BehRecipe.kt
@@ -11,6 +11,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -19,18 +20,14 @@ class BehRecipeShaped : MonsteraBuildableFile, MonsteraRawFile() {
     var data = BehRecipe()
 
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behRecipe ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for crafting recipe file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for crafting recipe file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for crafting recipe file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for crafting recipe file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             BehRecipe.FileHeaderShaped(
                 version ?: Addon.active?.config?.formatVersions?.behRecipe ?: "1.17.41",
                 data

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/BehSpawnRules.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/BehSpawnRules.kt
@@ -12,24 +12,21 @@ import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.spawnrules.conditions.*
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
 
 class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behBlocks ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for spawn rule file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for spawn rule file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for spawn rule file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for spawn rule file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behSpawnRules ?: "1.8.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
@@ -10,6 +10,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.shared.BehTableFun
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
@@ -22,17 +23,13 @@ class BehLootTables: MonsteraRawFile() {
     }
     class Block(val data: BehLootTables) : MonsteraBuildableFile {
         override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-            val sanFile = filename
-                .removeSuffix(".json")
-                .replace("-", "_")
-                .replace(" ", "_")
             val selPath = path ?: Addon.active?.config?.paths?.lootTableBlock ?: run {
-                getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block loot file '$sanFile' as no addon was initialized!")
-                return Result.failure(Error("Could not Resolve a path for block loot file '$sanFile' as no addon was initialized!"))
+                getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!")
+                return Result.failure(Error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!"))
             }
             val target = MonsteraBuilder.buildTo(
                 selPath,
-                "$sanFile.json",
+                sanetiseFilename(filename, "json"),
                 data
             )
             return Result.success(target)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/trading/BehEconomyTrades.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/trading/BehEconomyTrades.kt
@@ -10,6 +10,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.shared.BehTableFun
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -23,18 +24,14 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
     }
 
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behTrading ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for tade table file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for tade table file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for tade table file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for tade table file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             this
         )
         return Result.success(target)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
@@ -25,7 +25,7 @@ fun generateManifest(
     val enableScripting = scriptEntryFile.exists() && scriptEntryFile.isFile
 
     if (enableScripting && config.targetMcVersion[0] == 1 && config.targetMcVersion[1] < 20) {
-        logger.warn("Scripting is only available in version 1.20 or greater! Update your targetMcVersion!")
+        logger.warn("Scripting is only available in version 1.20 or higher! Update your targetMcVersion!")
     }
 
     //Manifest

--- a/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
@@ -18,7 +18,7 @@ import java.util.*
 fun generateManifest(
     version: MutableList<Int> = arrayListOf(1, 0, 0),
     config: Config,
-    minEnginVersion: ArrayList<Int> = config.targetMcVersion,
+    minEnginVersion: MutableList<Int> = config.targetMcVersion,
     scriptEntryFile: File = File()
 ): Pair<UUID, UUID> {
     val logger = LoggerFactory.getLogger("Manifest")

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/attachables/ResAttachable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/attachables/ResAttachable.kt
@@ -12,6 +12,7 @@ import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -20,18 +21,14 @@ class ResAttachable : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
         if(isEmtpy())
             return Result.failure(Error("File is empty!"))
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resAttachable ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for attachable file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for attachable file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for attachable file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for attachable file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.resAttachable ?: "1.10.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/entities/ResEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/entities/ResEntity.kt
@@ -10,10 +10,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.addon.molang.Query
-import com.lop.devtools.monstera.files.MonsteraBuilder
-import com.lop.devtools.monstera.files.MonsteraRawFile
-import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
-import com.lop.devtools.monstera.files.getUniqueFileName
+import com.lop.devtools.monstera.files.*
 import com.lop.devtools.monstera.files.res.TextureIndex
 import com.lop.devtools.monstera.files.res.entities.comp.*
 import com.lop.devtools.monstera.files.res.materials.Material
@@ -24,18 +21,14 @@ import java.nio.file.Path
 
 class ResEntity: MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resEntity ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for entity file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for entity file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.resEntity ?: "1.10.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/items/ResItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/items/ResItem.kt
@@ -11,20 +11,20 @@ import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.res.ItemTextureIndex
 import com.lop.devtools.monstera.files.res.TextureIndex
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
 class ResItem : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename.removeSuffix(".json").replace("-", "_").replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resItem ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res item file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for res item file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res item file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for res item file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.resItem ?: "1.10.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderControllers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderControllers.kt
@@ -7,22 +7,22 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
 class ResRenderControllers : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename.removeSuffix(".json").replace("-", "_").replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resRenderControllers ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res render controller file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for res render controller file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res render controller file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for res render controller file '$filename' as no addon was initialized!"))
         }
         Addon.active?.config?.formatVersions?.resRendercontroller?.let { formatVersion = it }
         version?.let { formatVersion = it }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             this
         )
         return Result.success(target)

--- a/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
@@ -3,58 +3,62 @@ package com.lop.devtools.monstera
 import com.lop.devtools.monstera.addon.addon
 import com.lop.devtools.monstera.files.getResource
 import java.awt.Color
+import kotlin.test.Test
 
-fun main() {
-    val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
-        getMonsteraLogger("addon").error(it.message)
-        it.printStackTrace()
-        return
-    }
+class Integration {
+    @Test
+    fun intTest() {
+        val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
+                getMonsteraLogger("addon").error(it.message)
+                it.printStackTrace()
+                return
+            }
 
-    val conf2 = config("my_test")  {
-        namespace = "monstera"
-        projectShort = "te"
-    }
+            val conf2 = config("my_test")  {
+                namespace = "monstera"
+                projectShort = "te"
+            }
 
-    addon(
-       conf2
-    ) {
-        entity("my_test_entity", "My Test Entity") {
-            behaviour {
-                components {
-                    physics {  }
-                    pushable {  }
+            addon(
+            conf1
+            ) {
+                entity("my_test_entity", "My Test Entity") {
+                    behaviour {
+                        components {
+                            physics {  }
+                            pushable {  }
+                        }
+                        properties {
+                            enum("1rwong_start") {
+                                default("abc")
+                                values = mutableListOf("abc", "ab")
+                            }
+                            enum("missing_default") {
+                                values = mutableListOf("a")
+                            }
+                            enum("missing_values") {
+                                default("ab")
+                            }
+                        }
+
+                        craftingRecipe {
+
+                        }
+                    }
+                    resource {
+                        components {
+                            spawnEgg("Spawn $name") {
+                                eggByColor(Color.CYAN, Color.BLACK)
+                            }
+                        }
+                    }
                 }
-                properties {
-                    enum("1rwong_start") {
-                        default("abc")
-                        values = mutableListOf("abc", "ab")
-                    }
-                    enum("missing_default") {
-                        values = mutableListOf("a")
-                    }
-                    enum("missing_values") {
-                        default("ab")
-                    }
-                }
+                entity("aververyverlongnametahtisshurlytoolongthanks") {
 
-                craftingRecipe {
+                }
+                item("my_item", "My Item") {
 
                 }
             }
-            resource {
-                components {
-                    spawnEgg("Spawn $name") {
-                        eggByColor(Color.CYAN, Color.BLACK)
-                    }
-                }
-            }
-        }
-        entity("aververyverlongnametahtisshurlytoolongthanks") {
-
-        }
-        item("my_item", "My Item") {
-            
-        }
     }
 }

--- a/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
@@ -9,56 +9,56 @@ class Integration {
     @Test
     fun intTest() {
         val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
-                getMonsteraLogger("addon").error(it.message)
-                it.printStackTrace()
-                return
-            }
+            getMonsteraLogger("addon").error(it.message)
+            it.printStackTrace()
+            return
+        }
 
-            val conf2 = config("my_test")  {
-                namespace = "monstera"
-                projectShort = "te"
-            }
+        val conf2 = config("my_test") {
+            namespace = "monstera"
+            projectShort = "te"
+        }
 
-            addon(
+        addon(
             conf1
-            ) {
-                entity("my_test_entity", "My Test Entity") {
-                    behaviour {
-                        components {
-                            physics {  }
-                            pushable {  }
+        ) {
+            entity("my_test_entity", "My Test Entity") {
+                behaviour {
+                    components {
+                        physics { }
+                        pushable { }
+                    }
+                    properties {
+                        enum("1rwong_start") {
+                            default("abc")
+                            values = mutableListOf("abc", "ab")
                         }
-                        properties {
-                            enum("1rwong_start") {
-                                default("abc")
-                                values = mutableListOf("abc", "ab")
-                            }
-                            enum("missing_default") {
-                                values = mutableListOf("a")
-                            }
-                            enum("missing_values") {
-                                default("ab")
-                            }
+                        enum("missing_default") {
+                            values = mutableListOf("a")
                         }
-
-                        craftingRecipe {
-
+                        enum("missing_values") {
+                            default("ab")
                         }
                     }
-                    resource {
-                        components {
-                            spawnEgg("Spawn $name") {
-                                eggByColor(Color.CYAN, Color.BLACK)
-                            }
-                        }
+
+                    craftingRecipe {
+
                     }
                 }
-                entity("aververyverlongnametahtisshurlytoolongthanks") {
-
-                }
-                item("my_item", "My Item") {
-
+                resource {
+                    components {
+                        spawnEgg("Spawn $name") {
+                            eggByColor(Color.CYAN, Color.BLACK)
+                        }
+                    }
                 }
             }
+            entity("aververyverlongnametahtisshurlytoolongthanks") {
+
+            }
+            item("my_item", "My Item") {
+
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
@@ -1,13 +1,24 @@
 package com.lop.devtools.monstera
 
 import com.lop.devtools.monstera.addon.addon
+import com.lop.devtools.monstera.files.getResource
 import java.awt.Color
 
 fun main() {
-    addon(config("testPrj") {
-        description = "This is a Test Project"
-        //packIcon = getResource("pack.png")
-    }) {
+    val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
+        getMonsteraLogger("addon").error(it.message)
+        it.printStackTrace()
+        return
+    }
+
+    val conf2 = config("my_test")  {
+        namespace = "monstera"
+        projectShort = "te"
+    }
+
+    addon(
+       conf2
+    ) {
         entity("my_test_entity", "My Test Entity") {
             behaviour {
                 components {

--- a/src/test/kotlin/com/lop/devtools/monstera/addon/entitiy/AnimControllerTest.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/addon/entitiy/AnimControllerTest.kt
@@ -19,6 +19,7 @@ class AnimControllerTest {
     @OptIn(MonsteraExperimental::class)
     @Test
     fun basicAnimControllerTest() = testAddon {
+        buildToMcFolder = true
         entity("my_anim_test", "Anim Test") {
             behaviour {
                 components {

--- a/src/test/resources/monstera-local.json
+++ b/src/test/resources/monstera-local.json
@@ -1,0 +1,4 @@
+{
+    "projectPath": "",
+    "buildPath": "build"
+}

--- a/src/test/resources/monstera.json
+++ b/src/test/resources/monstera.json
@@ -1,0 +1,69 @@
+{
+    "name": "Test Project",
+    "projectShort": "tpr",
+    "description": "My test Project",
+    "namespace": "monstera",
+    "version": [
+        0,
+        0,
+        1
+    ],
+    "authors": [
+        "Matthias Klenz"
+    ],
+    "worldUUID": "fe8b47f7-dfe9-4ad1-ac1f-18b8fda6bba6",
+    "worldModuleUUID": "8ac9af62-3bcd-4ebc-9600-a53ba72378fa",
+    "behUUID": "01ad7aa7-917a-45d4-8678-29dce3d36e05",
+    "behModuleUUID": "f60f5b8c-f5ff-4648-b069-e0554531b3df",
+    "scriptUUID": "a7966416-236e-4da7-a7e6-fe3f13ab8c79",
+    "resUUID": "c9a9728b-af73-4251-bcea-e4df4371f309",
+    "resModuleUUID": "41b5e80e-b651-46a7-a3c1-f3d829020ef0",
+    "targetMcVersion": [
+        1,
+        20,
+        70
+    ],
+    "scriptingVersion": "1.8.0",
+    "minecraftPaths": {
+        "behEntity": "entities",
+        "behAnimController": "animation_controllers",
+        "behAnim": "animations",
+        "behBlocks": "blocks",
+        "behItems": "items",
+        "lootTableEntity": "loot_tables/entities",
+        "lootTableBlock": "loot_tables/blocks",
+        "behSpawnRules": "spawn_rules",
+        "behTrading": "trading/economy_trades",
+        "behRecipes": "recipes",
+        "behTexts": "texts",
+        "behScripts": "scripts",
+        "behMcFunction": "functions",
+        "resAnim": "animations",
+        "resAnimController": "animation_controllers",
+        "resEntity": "entity",
+        "resItem": "items",
+        "resModels": "models",
+        "resMaterials": "materials",
+        "resParticles": "particles",
+        "resRenderControllers": "render_controllers",
+        "resSounds": "sounds",
+        "resTextures": "textures",
+        "resAttachable": "attachables",
+        "resTexts": "texts"
+    },
+    "minecraftFormatVersions": {
+        "behEntitty": "1.20.70",
+        "behItem": "1.10.0",
+        "behAnim": "1.8.0",
+        "behBlock": "1.20.70",
+        "behRecipe": "1.17.41",
+        "behSpawnRule": "1.8.0",
+        "behAnimController": "1.10.0",
+        "resEntity": "1.10.0",
+        "resItem": "1.10.0",
+        "resAnimController": "1.10.0",
+        "resAttachable": "1.10.0",
+        "resSoundDefs": "1.14.0",
+        "resRenderController": "1.10.0"
+    }
+}

--- a/src/test/resources/monstera.json
+++ b/src/test/resources/monstera.json
@@ -26,6 +26,7 @@
     ],
     "scriptingVersion": "1.8.0",
     "packIcon": "src/main/resources/pack.png",
+    "hashFileNames": true,
     "minecraftPaths": {
         "behEntity": "entities",
         "behAnimController": "animation_controllers",

--- a/src/test/resources/monstera.json
+++ b/src/test/resources/monstera.json
@@ -11,6 +11,7 @@
     "authors": [
         "Matthias Klenz"
     ],
+    "world": "src/main/resources/template-wrold",
     "worldUUID": "fe8b47f7-dfe9-4ad1-ac1f-18b8fda6bba6",
     "worldModuleUUID": "8ac9af62-3bcd-4ebc-9600-a53ba72378fa",
     "behUUID": "01ad7aa7-917a-45d4-8678-29dce3d36e05",
@@ -24,6 +25,7 @@
         70
     ],
     "scriptingVersion": "1.8.0",
+    "packIcon": "src/main/resources/pack.png",
     "minecraftPaths": {
         "behEntity": "entities",
         "behAnimController": "animation_controllers",


### PR DESCRIPTION
Add the possibility to create the monstera config as a json file within the project.
Split up into 2 files:
- monstera.json, is project related
- monstera-local.json, contains the developer related settings like the mc directory