### PR TITLE
Inject additional keys in all file types

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -7,3 +7,4 @@
 * [Items](./pages/Items.md)
 * [Molang](./pages/Molang.md)
 * [Sounds](./pages/Sounds.md)
+* [Marketplace](./pages/Marketplace.md)

--- a/docs/pages/Marketplace.md
+++ b/docs/pages/Marketplace.md
@@ -1,0 +1,25 @@
+# Marketplace
+
+This page is not finished!
+
+## Formatting
+
+Monstera tries to remain Marketplace compliant by default, but there are some places where a developer has to configure
+things themselves.
+
+### Addons
+
+For addons, Marketplace teams must place entities, blocks or other files in their own subfolders to prevent collisions
+with files from other Marketplace teams. You can customize all paths in the monstera.json file for this purpose. For
+example:
+"behEntity": "entities" -> "behEntity": "entities/partner_name"
+
+### Other
+
+Collisions with other add-ons are not normally a problem, as you can assume that the developed add-on is the only one
+that is active.
+
+## Packaging
+
+It is possible to create a zip file using the standard library that is Marketplace compatible. This can still be complex
+under certain circumstances, but has the advantage of benefiting from a version control system (such as Git).

--- a/src/main/kotlin/com/lop/devtools/monstera/Config.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/Config.kt
@@ -80,6 +80,7 @@ fun loadConfig(
             resUUID = UUID.fromString(monsteraConfig.resUUID),
             resModUUID = UUID.fromString(monsteraConfig.resModuleUUID),
             targetMcVersion = monsteraConfig.targetMcVersion,
+            hashFileNames = monsteraConfig.hashFileNames,
             behPath = behPath,
             resPath = resPath,
 
@@ -164,6 +165,7 @@ class MonsteraConfig(
     var scriptingVersion: String,
     var scriptEntryFile: String?,
     var packIcon: String?,
+    var hashFileNames: Boolean = false,
     var minecraftPaths: MinecraftAddonPaths,
     var minecraftFormatVersions: MinecraftFormatVersions,
 )
@@ -249,7 +251,8 @@ class Config(
     var formatVersions: FormatVersions = FormatVersions(getVersionAsString(targetMcVersion)),
     var langFileBuilder: AddonLangFileBuilders = AddonLangFileBuilders(behPath, resPath),
     var scriptEntryFile: File = File(),
-    var scriptingVersion: String = "1.8.0"
+    var scriptingVersion: String = "1.8.0",
+    var hashFileNames: Boolean = false
 ) {
     init {
         behPath.toFile().deleteRecursively()

--- a/src/main/kotlin/com/lop/devtools/monstera/Config.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/Config.kt
@@ -2,6 +2,7 @@
 
 package com.lop.devtools.monstera
 
+import com.google.gson.Gson
 import com.lop.devtools.monstera.addon.dev.ResourceLoader
 import com.lop.devtools.monstera.addon.entity.resource.copyDefaultTextureTo
 import com.lop.devtools.monstera.addon.entity.resource.generateDefaultGeo
@@ -18,9 +19,191 @@ import kotlin.io.path.Path
 annotation class ConfigDSL
 
 @ConfigDSL
+@Deprecated("Use a config file, this function does not correcly apply config data!",
+    ReplaceWith("loadConfig()", "com.lop.devtools.monstera.Config")
+)
 fun config(projectName: String, data: Config.() -> Unit): Config {
     return Config(projectName).apply(data)
 }
+
+@ConfigDSL
+fun loadConfig(
+    conf: String = "${System.getProperty("user.dir")}/monstera.json",
+    local: String = "${System.getProperty("user.dir")}/monstera-local.json"
+) = loadConfig(File(conf), File(local))
+
+@ConfigDSL
+fun loadConfig(
+    conf: File,
+    local: File
+): Result<Config> {
+    if (!conf.exists() || !local.exists()) {
+        return Result.failure(Error("Could not find config file!"))
+    }
+
+    try {
+        val gson = Gson()
+        val monsteraConfig: MonsteraConfig = gson.fromJson(conf.readText(), MonsteraConfig::class.java)
+        val monsteraLocalConfig: MonsteraLocalConfig =
+            gson.fromJson(local.readText(), MonsteraLocalConfig::class.java)
+
+        val behPath = Path(
+            System.getProperty("user.dir"),
+            monsteraLocalConfig.buildPath,
+            "development_behavior_packs",
+            monsteraConfig.projectShort.uppercase() + "_BP"
+        )
+        val resPath = Path(
+            System.getProperty("user.dir"),
+            monsteraLocalConfig.buildPath,
+            "development_resource_packs",
+            monsteraConfig.projectShort.uppercase() + "_BP"
+        )
+
+        val config = Config(
+            projectName = monsteraConfig.name,
+            namespace = monsteraConfig.namespace,
+            projectShort = monsteraConfig.projectShort,
+            description = monsteraConfig.description,
+            version = monsteraConfig.version,
+            authors = monsteraConfig.authors,
+            worldUUID = UUID.fromString(monsteraConfig.worldUUID),
+            worldModuleUUID = UUID.fromString(monsteraConfig.worldModuleUUID),
+            behUUID = UUID.fromString(monsteraConfig.behUUID),
+            behModUUID = UUID.fromString(monsteraConfig.behModuleUUID),
+            behScriptUUID = UUID.fromString(monsteraConfig.scriptUUID),
+            resUUID = UUID.fromString(monsteraConfig.resUUID),
+            resModUUID = UUID.fromString(monsteraConfig.resModuleUUID),
+            targetMcVersion = monsteraConfig.targetMcVersion,
+            behPath = behPath,
+            resPath = resPath,
+
+            comMojangPath = monsteraLocalConfig.minecraftDir?.let { Path(it) }
+                ?: Path(
+                    System.getenv("LOCALAPPDATA") ?: "",
+                    "Packages",
+                    "Microsoft.MinecraftUWP_8wekyb3d8bbwe",
+                    "LocalState",
+                    "games",
+                    "com.mojang"
+                ),
+            paths = Config.AddonPaths(
+                behBase = behPath,
+                resBase = resPath,
+                behEntity = behPath.resolve(monsteraConfig.minecraftPaths.behEntity),
+                behAnimController = behPath.resolve(monsteraConfig.minecraftPaths.behAnimController),
+                behAnim = behPath.resolve(monsteraConfig.minecraftPaths.behAnim),
+                behRecipe = behPath.resolve(monsteraConfig.minecraftPaths.behRecipes),
+                behBlocks = behPath.resolve(monsteraConfig.minecraftPaths.behBlocks),
+                behItems = behPath.resolve(monsteraConfig.minecraftPaths.behItems),
+                behSpawnRules = behPath.resolve(monsteraConfig.minecraftPaths.behSpawnRules),
+                behTrading = behPath.resolve(monsteraConfig.minecraftPaths.behTrading),
+                behTexts = behPath.resolve(monsteraConfig.minecraftPaths.behTexts),
+                behScripts = behPath.resolve(monsteraConfig.minecraftPaths.behScripts),
+                behMcFunction = behPath.resolve(monsteraConfig.minecraftPaths.behMcFunction),
+                resAnim = resPath.resolve(monsteraConfig.minecraftPaths.resAnim),
+                resItem = resPath.resolve(monsteraConfig.minecraftPaths.resItem),
+                resModels = resPath.resolve(monsteraConfig.minecraftPaths.resModels),
+                resMaterials = resPath.resolve(monsteraConfig.minecraftPaths.resMaterials),
+                resParticles = resPath.resolve(monsteraConfig.minecraftPaths.resParticles),
+                resRenderControllers = resPath.resolve(monsteraConfig.minecraftPaths.resRenderControllers),
+                resSounds = resPath.resolve(monsteraConfig.minecraftPaths.resSounds),
+                resTextures = resPath.resolve(monsteraConfig.minecraftPaths.resTextures),
+                resAttachable = resPath.resolve(monsteraConfig.minecraftPaths.resAttachable),
+                resTexts = resPath.resolve(monsteraConfig.minecraftPaths.resTexts),
+            ),
+            formatVersions = Config.FormatVersions(
+                getVersionAsString(monsteraConfig.targetMcVersion),
+                behEntity = monsteraConfig.minecraftFormatVersions.behEntitty,
+                resEntity = monsteraConfig.minecraftFormatVersions.resEntity,
+                resItem = monsteraConfig.minecraftFormatVersions.resItem,
+                behItem = monsteraConfig.minecraftFormatVersions.behItem,
+                behAnimation = monsteraConfig.minecraftFormatVersions.behAnim,
+                behBlock = monsteraConfig.minecraftFormatVersions.behBlock,
+                behRecipe = monsteraConfig.minecraftFormatVersions.behRecipe,
+                behSpawnRules = monsteraConfig.minecraftFormatVersions.behSpawnRule,
+                behAnimController = monsteraConfig.minecraftFormatVersions.behAnimController,
+                resAnimController = monsteraConfig.minecraftFormatVersions.resAnimController,
+                resAttachable = monsteraConfig.minecraftFormatVersions.resAttachable,
+                resSoundDefs = monsteraConfig.minecraftFormatVersions.resSoundDefs,
+                resRendercontroller = monsteraConfig.minecraftFormatVersions.resRenderController,
+            )
+        )
+        return Result.success(config)
+    } catch (e: Exception) {
+        return Result.failure(e)
+    }
+}
+
+class MonsteraConfig(
+    var name: String,
+    var projectShort: String,
+    var description: String,
+    var namespace: String,
+    var version: MutableList<Int>,
+    var authors: MutableList<String>,
+    var worldUUID: String,
+    var worldModuleUUID: String,
+    var behUUID: String,
+    var behModuleUUID: String,
+    var scriptUUID: String,
+    var resUUID: String,
+    var resModuleUUID: String,
+    var targetMcVersion: MutableList<Int>,
+    var scriptingVersion: String,
+    var minecraftPaths: MinecraftAddonPaths,
+    var minecraftFormatVersions: MinecraftFormatVersions,
+)
+
+class MinecraftAddonPaths(
+    var behEntity: String,
+    var behAnimController: String,
+    var behAnim: String,
+    var behBlocks: String,
+    var behItems: String,
+    var lootTableEntity: String,
+    var lootTableBlock: String,
+    var behSpawnRules: String,
+    var behTrading: String,
+    var behRecipes: String,
+    var behTexts: String,
+    var behScripts: String,
+    var behMcFunction: String,
+    var resAnim: String,
+    var resAnimController: String,
+    var resEntity: String,
+    var resItem: String,
+    var resModels: String,
+    var resMaterials: String,
+    var resParticles: String,
+    var resRenderControllers: String,
+    var resSounds: String,
+    var resTextures: String,
+    var resAttachable: String,
+    var resTexts: String,
+)
+
+class MinecraftFormatVersions(
+    var behEntitty: String,
+    var behItem: String,
+    var behAnim: String,
+    var behBlock: String,
+    var behRecipe: String,
+    var behSpawnRule: String,
+    var behAnimController: String,
+    var resEntity: String,
+    var resItem: String,
+    var resAnimController: String,
+    var resAttachable: String,
+    var resSoundDefs: String,
+    var resRenderController: String,
+)
+
+class MonsteraLocalConfig(
+    var projectPath: String?,
+    var buildPath: String,
+    var minecraftDir: String?
+)
 
 class Config(
     val projectName: String,
@@ -49,7 +232,7 @@ class Config(
         "com.mojang"
     ),
     var paths: AddonPaths = AddonPaths(behPath, resPath),
-    var targetMcVersion: ArrayList<Int> = arrayListOf(1, 20, 70),
+    var targetMcVersion: MutableList<Int> = arrayListOf(1, 20, 70),
     var formatVersions: FormatVersions = FormatVersions(getVersionAsString(targetMcVersion)),
     var langFileBuilder: AddonLangFileBuilders = AddonLangFileBuilders(behPath, resPath),
     var scriptEntryFile: File = File(),
@@ -151,4 +334,3 @@ class Config(
         var resRendercontroller: String = "1.10.0"
     )
 }
-

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/Addon.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/Addon.kt
@@ -62,7 +62,7 @@ open class Addon(val config: Config) {
     var buildTextureList: Boolean = true
     var buildItemTextureIndex: Boolean = true
     var buildToMcFolder: Boolean = true
-    var manifestMinEnginVersion: ArrayList<Int> = config.targetMcVersion
+    var manifestMinEnginVersion: ArrayList<Int> = ArrayList(config.targetMcVersion)
 
     var includeInfoMcFunction: Boolean = true
 
@@ -283,7 +283,7 @@ open class Addon(val config: Config) {
         generateManifest(
             config.version,
             config,
-            minEnginVersion = manifestMinEnginVersion,
+            minEnginVersion = ArrayList(manifestMinEnginVersion),
             scriptEntryFile = config.scriptEntryFile
         )
 

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/BasicAddon.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/BasicAddon.kt
@@ -7,7 +7,7 @@ import kotlin.system.measureTimeMillis
 @DslMarker
 annotation class AddonEntry
 
-class BasicAddon(config: Config) : Addon(config) {
+class BasicAddon(config: Config, args: Array<String>) : Addon(config, args) {
     init {
         active = this
     }
@@ -15,24 +15,24 @@ class BasicAddon(config: Config) : Addon(config) {
 
 
 @AddonEntry
-fun addon(config: Config, addon: Addon.() -> Unit): Config {
+fun addon(config: Config, args: Array<String> = arrayOf(), addon: Addon.() -> Unit): Config {
     val logger = getMonsteraLogger("Monstera")
     logger.info("Building Addon ...")
     val buildTime = measureTimeMillis {
-        BasicAddon(config).apply(addon).build()
+        BasicAddon(config, args).apply(addon).build()
     }
     logger.info("Finished building Addon in ${buildTime / 1000}.${buildTime % 1000}s")
     return config
 }
 
 @AddonEntry
-fun addon(projectName: String, conf: Config.() -> Unit = {}, addon: Addon.() -> Unit): Config {
-    return addon(Config(projectName).apply(conf), addon)
+fun addon(projectName: String, args: Array<String> = arrayOf(), conf: Config.() -> Unit = {}, addon: Addon.() -> Unit): Config {
+    return addon(Config(projectName).apply(conf), args, addon)
 }
 
 @AddonEntry
 fun testAddon(addon: Addon.() -> Unit) {
-    (Addon.active ?: BasicAddon(Config("test_prj"))).apply { buildToMcFolder = false }.apply(addon)
+    (Addon.active ?: BasicAddon(Config("test_prj"), arrayOf())).apply { buildToMcFolder = false }.apply(addon)
 }
 
 fun buildTestAddon() {

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/api/MonsteraAnnotation.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/api/MonsteraAnnotation.kt
@@ -9,6 +9,14 @@ package com.lop.devtools.monstera.addon.api
 @RequiresOptIn("This field should not be modified within an addon", RequiresOptIn.Level.ERROR)
 annotation class MonsteraBuildSetter
 
+@Target(AnnotationTarget.PROPERTY_SETTER, AnnotationTarget.FUNCTION)
+@Retention(AnnotationRetention.RUNTIME)
+@RequiresOptIn(
+    "This field should doesn't do anything, this is in place to protect the developer from assigning variables in another context",
+    RequiresOptIn.Level.ERROR
+)
+annotation class MonsteraInvalidField
+
 /**
  * this annotation indicates code that should only be used for debug purposes, this can also mean that one might want to
  * retrieve this information for their plugin/feature to give a better debug message if a user of set code makes a mistake

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/dev/MinecraftFolderBuilder.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/dev/MinecraftFolderBuilder.kt
@@ -7,6 +7,14 @@ import kotlinx.coroutines.runBlocking
 import org.slf4j.LoggerFactory
 import java.nio.file.Path
 
+fun overwriteResourceInMcFolder(config: Config) {
+    val mojangRes = config
+        .comMojangPath
+        .resolve("development_resource_packs")
+        .resolve(config.projectShort.uppercase() + "_RP")
+    config.resPath.toFile().copyRecursively(mojangRes.toFile(), true)
+}
+
 fun buildToMcFolder(config: Config) = runBlocking {
     val logger = LoggerFactory.getLogger("Mc Directory Builder")
 
@@ -41,7 +49,8 @@ fun buildToMcFolder(config: Config) = runBlocking {
 
     if (config.world.exists()) {
         try {
-            val worldFolderPath = config.comMojangPath.resolve("minecraftWorlds").resolve(config.projectShort + "_world")
+            val worldFolderPath =
+                config.comMojangPath.resolve("minecraftWorlds").resolve(config.projectShort + "_world")
             worldFolderPath.toFile().deleteRecursively()
             config.world.copyRecursively(worldFolderPath.toFile())
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/KotlinUtil.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/KotlinUtil.kt
@@ -1,5 +1,6 @@
 package com.lop.devtools.monstera.files
 
+import com.lop.devtools.monstera.addon.Addon
 import java.io.File
 import java.io.FileNotFoundException
 import java.nio.ByteBuffer
@@ -61,6 +62,35 @@ fun getUniqueFileName(file: File): String {
         .replace("+", "")
         .replace("/", "")
     return enc + "_" + file.name
+}
+
+fun sanetiseFilename(filename: String, fileSuffix: String): String {
+    var sanFile = filename
+        .removeSuffix(".$fileSuffix")
+        .replace("-", "_")
+        .replace(" ", "_")
+    if(Addon.active?.config?.hashFileNames == true) {
+        sanFile = getUniqueBuildFileName(Addon.active!!.config.namespace, sanFile)
+    }
+    return "${sanFile}.$fileSuffix"
+}
+
+/**
+ * create a hash out of the namespace and fileName and append it to the fileName
+ * @param namespace the namespace of the project
+ * @param filename the file name to make unique
+ * @return a unique fileName to the namespace and fileName, this might be required if multiple addons are loaded with diffrent namespaces but same file names
+ */
+fun getUniqueBuildFileName(namespace: String, filename: String): String {
+    val hash = namespace.hashCode() + filename.hashCode()
+    val buff = ByteBuffer.allocate(Int.SIZE_BYTES).putInt(hash).array()
+    val enc = Base64
+        .getEncoder()
+        .encodeToString(buff)
+        .replace("=", "")
+        .replace("+", "")
+        .replace("/", "")
+    return "${filename}_$enc"
 }
 
 fun File(vararg parents: String): File {

--- a/src/main/kotlin/com/lop/devtools/monstera/files/MonsteraDesrializer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/MonsteraDesrializer.kt
@@ -9,13 +9,56 @@ open class MonsteraRawFile {
 
 class MonsteraRawFileTypeAdapter : JsonSerializer<MonsteraRawFile> {
     override fun serialize(src: MonsteraRawFile?, typeOfSrc: Type?, context: JsonSerializationContext?): JsonElement {
-        if(src == null) return JsonNull.INSTANCE
+        if (src == null) return JsonNull.INSTANCE
         val obj = context?.serialize(src) ?: JsonObject()
-        if(obj is JsonObject) {
+        if (obj is JsonObject) {
             src.additionalKeys?.forEach { (k, v) ->
                 obj.add(k, context?.serialize(v))
             }
         }
         return obj
+    }
+}
+
+class MonsteraMapFileTypeAdapter : JsonSerializer<Map<String, MonsteraRawFile>> {
+    override fun serialize(
+        src: Map<String, MonsteraRawFile>?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        if (src == null) return JsonNull.INSTANCE
+        val obj = context?.serialize(src) ?: JsonObject()
+        if (obj is JsonObject) {
+            src.forEach { (mapKey, mapValue) ->
+                mapValue.additionalKeys?.forEach { (addKey, addValue) ->
+                    if (obj[mapKey] == null) {
+                        obj.add(mapKey, JsonObject())
+                    }
+                    (obj[mapKey] as JsonObject).add(addKey, context?.serialize(addValue))
+                }
+            }
+        }
+        return obj
+    }
+}
+
+class MonsteraListFileTypeAdapter : JsonSerializer<List<MonsteraRawFile>> {
+    override fun serialize(
+        src: List<MonsteraRawFile>?,
+        typeOfSrc: Type?,
+        context: JsonSerializationContext?
+    ): JsonElement {
+        if (src == null) return JsonNull.INSTANCE
+        val arr = JsonArray()
+        src.forEach { listItem ->
+            val obj = context?.serialize(listItem) ?: JsonObject()
+            if (obj is JsonObject) {
+                listItem.additionalKeys?.forEach { (k, v) ->
+                    obj.add(k, context?.serialize(v))
+                }
+            }
+            arr.add(obj)
+        }
+        return arr
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimationControllers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimationControllers.kt
@@ -9,11 +9,10 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.addon.api.MonsteraExperimental
 import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.addon.molang.Query
-import com.lop.devtools.monstera.addon.molang.Variable
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
-import java.lang.Error
 import java.nio.file.Path
 
 class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
@@ -21,14 +20,10 @@ class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
         if(animationControllersData.isEmpty())
             return Result.failure(Error("Animation Controller Data is empty, building does nothing!"))
 
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         if(path == null)
             error("path may not be null! can't build anim controller when not clear if beh or res.")
 
-        val target = MonsteraBuilder.buildTo(path, "$sanFile.json", this)
+        val target = MonsteraBuilder.buildTo(path, sanetiseFilename(filename, "json"), this)
         return Result.success(target)
     }
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimationControllers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/animcontroller/AnimationControllers.kt
@@ -3,6 +3,7 @@
 package com.lop.devtools.monstera.files.animcontroller
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
@@ -10,17 +11,18 @@ import com.lop.devtools.monstera.addon.api.MonsteraExperimental
 import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.addon.molang.Query
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraMapFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
-class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
+class AnimationControllers : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        if(animationControllersData.isEmpty())
+        if (animationControllersData.isEmpty())
             return Result.failure(Error("Animation Controller Data is empty, building does nothing!"))
 
-        if(path == null)
+        if (path == null)
             error("path may not be null! can't build anim controller when not clear if beh or res.")
 
         val target = MonsteraBuilder.buildTo(path, sanetiseFilename(filename, "json"), this)
@@ -38,6 +40,7 @@ class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("animation_controllers")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var animationControllersData: MutableMap<String, Controller> = mutableMapOf()
         @MonsteraBuildSetter set
 
@@ -59,13 +62,14 @@ class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
         }
     }
 
-    open class Controller {
+    open class Controller : MonsteraRawFile() {
         @SerializedName("initial_state")
         @Expose
         var initialState: String? = null
 
         @SerializedName("states")
         @Expose
+        @JsonAdapter(MonsteraMapFileTypeAdapter::class)
         var statesData: MutableMap<String, State>? = null
 
         fun state(name: String, data: State.() -> Unit) {
@@ -94,7 +98,7 @@ class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
          */
         @MonsteraExperimental
         fun variables(data: VariableApi.() -> Unit) {
-            if(initialState == null) {
+            if (initialState == null) {
                 getMonsteraLogger(this::class.simpleName ?: "Animation Controller")
                     .warn("Variable initialisation 'variable { ... }' is only possible after 'initialState' is set!")
             }
@@ -108,14 +112,14 @@ class AnimationControllers: MonsteraBuildableFile, MonsteraRawFile() {
             }
             state("variable_init_2") {
                 onEntry = vars
-                transition(normalIni, Query.True )
+                transition(normalIni, Query.True)
             }
 
             initialState = "variable_init"
         }
     }
 
-    open class State {
+    open class State : MonsteraRawFile() {
 
         /**
          * resource pack only!

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimation.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimation.kt
@@ -3,8 +3,9 @@ package com.lop.devtools.monstera.files.beh.animations
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-open class BehAnimation {
+open class BehAnimation : MonsteraRawFile() {
     @SerializedName("timeline")
     @Expose
     var timelineData: MutableMap<String, MutableList<String>>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimations.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimations.kt
@@ -1,11 +1,13 @@
 package com.lop.devtools.monstera.files.beh.animations
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraMapFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
@@ -36,6 +38,7 @@ class BehAnimations : MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("animations")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var animData: MutableMap<String, BehAnimation>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimations.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/animations/BehAnimations.kt
@@ -7,24 +7,21 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
 
 class BehAnimations : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         version?.let { formatVersion = it }
 
         val buildPath = path ?: Addon.active?.config?.paths?.behAnim ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for animation file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for animation file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for animation file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for animation file '$filename' as no addon was initialized!"))
         }
 
-        val target = MonsteraBuilder.buildTo(buildPath, "$sanFile.json", this)
+        val target = MonsteraBuilder.buildTo(buildPath, sanetiseFilename(filename, "json"), this)
         return Result.success(target)
     }
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/blocks/BehBlocks.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/blocks/BehBlocks.kt
@@ -12,23 +12,20 @@ import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.blocks.components.BlockComponents
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
 class BehBlocks : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behBlocks ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for block file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for block file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behBlock ?: "1.20.50",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
@@ -9,13 +9,10 @@ import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.DebugMarker
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
-import com.lop.devtools.monstera.files.MonsteraBuilder
-import com.lop.devtools.monstera.files.MonsteraRawFile
-import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.*
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.description.BehEntityDescription
 import com.lop.devtools.monstera.files.beh.entitiy.events.BehEntityEvent
-import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -23,7 +20,7 @@ import java.nio.file.Path
 /**
  * Create an Entity with a description, componentGroups, components and events
  */
-class BehEntity : MonsteraBuildableFile {
+class BehEntity : MonsteraBuildableFile, MonsteraRawFile() {
     private fun logger() = getMonsteraLogger(this.javaClass.name)
 
     @SerializedName("description")
@@ -40,11 +37,13 @@ class BehEntity : MonsteraBuildableFile {
 
     @SerializedName("component_groups")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var componentGroupsData: MutableMap<String, Components>? = null
         @MonsteraBuildSetter set
 
     @SerializedName("events")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var eventsData: MutableMap<String, BehEntityEvent>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/BehEntity.kt
@@ -15,6 +15,7 @@ import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.description.BehEntityDescription
 import com.lop.devtools.monstera.files.beh.entitiy.events.BehEntityEvent
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -48,18 +49,14 @@ class BehEntity : MonsteraBuildableFile {
         @MonsteraBuildSetter set
 
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behEntity ?: run {
-            logger().error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!"))
+            logger().error("Could not Resolve a path for entity file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for entity file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behEntity ?: "1.20.50",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/BehEntityTypes.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/BehEntityTypes.kt
@@ -3,9 +3,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehEntityTypes {
+class BehEntityTypes : MonsteraRawFile() {
     @SerializedName("max_dist")
     @Expose
     var maxDist: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentValue.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/ComponentValue.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ComponentValue {
+class ComponentValue : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Any? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
@@ -4075,6 +4075,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.jump_to_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behJumpToBlockData: BehJumpToBlock? = null
         @MonsteraBuildSetter set
 
@@ -4101,6 +4102,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.lay_egg")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behLayEggData: BehLayEgg? = null
         @MonsteraBuildSetter set
 
@@ -4129,6 +4131,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.squid_move_away_from_ground")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSquidMoveAwayFromGroundData: BehSquidMoveAwayFromGround? = null
         @MonsteraBuildSetter set
 
@@ -4148,6 +4151,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.squid_flee")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSquidFleeData: BehSquidFlee? = null
         @MonsteraBuildSetter set
 
@@ -4167,6 +4171,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.squid_idle")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSquidIdleData: BehSquidIdle? = null
         @MonsteraBuildSetter set
 
@@ -4186,6 +4191,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.squid_dive")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSquidDiveData: BehSquidDive? = null
         @MonsteraBuildSetter set
 
@@ -4205,6 +4211,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.squid_out_of_water")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSquidOutOfWaterData: BehSquidOutOfWater? = null
         @MonsteraBuildSetter set
 
@@ -4224,6 +4231,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:genetics")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var geneticsData: Genetics? = null
         @MonsteraBuildSetter set
 
@@ -4243,6 +4251,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.ram_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRamAttackData: BehRamAttack? = null
         @MonsteraBuildSetter set
 
@@ -4270,6 +4279,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.avoid_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behAvoidBlockData: BehAvoidBlock? = null
         @MonsteraBuildSetter set
 
@@ -4296,6 +4306,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_shaking")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isShakingData: IsShaking? = null
         @MonsteraBuildSetter set
 
@@ -4314,6 +4325,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:transformation")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var transformationData: Transformation? = null
         @MonsteraBuildSetter set
 
@@ -4339,6 +4351,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:custom_hit_test")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var customHitTestData: CustomHitTest? = null
         @MonsteraBuildSetter set
 
@@ -4357,6 +4370,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:group_size")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var groupSizeData: GroupSize? = null
         @MonsteraBuildSetter set
 
@@ -4376,6 +4390,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:item_hopper")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var itemHopperData: ItemHopper? = null
         @MonsteraBuildSetter set
 
@@ -4394,6 +4409,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.find_mount")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFindMountData: BehFindMount? = null
         @MonsteraBuildSetter set
 
@@ -4419,6 +4435,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:preferred_path")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var preferredPathData: PreferredPath? = null
         @MonsteraBuildSetter set
 
@@ -4440,6 +4457,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.target_when_pushed")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTargetWhenPushedData: BehTargetWhenPushed? = null
         @MonsteraBuildSetter set
 
@@ -4460,6 +4478,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_towards_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveTowardsTargetData: BehMoveTowardsTarget? = null
         @MonsteraBuildSetter set
 
@@ -4481,6 +4500,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_through_village")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveThroughVillageData: BehMoveThroughVillage? = null
         @MonsteraBuildSetter set
 
@@ -4502,6 +4522,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.offer_flower")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behOfferFlowerData: BehOfferFlower? = null
         @MonsteraBuildSetter set
 
@@ -4521,6 +4542,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.defend_village_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDefendVillageTargetData: BehDefendVillageTarget? = null
         @MonsteraBuildSetter set
 
@@ -4542,6 +4564,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.follow_caravan")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFollowCaravanData: BehFollowCaravan? = null
         @MonsteraBuildSetter set
 
@@ -4563,6 +4586,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:strength")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var strengthData: Strength? = null
         @MonsteraBuildSetter set
 
@@ -4583,6 +4607,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:area_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var areaAttackData: AreaAttack? = null
         @MonsteraBuildSetter set
 
@@ -4605,6 +4630,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.jump")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementJumpData: MovementJump? = null
         @MonsteraBuildSetter set
 
@@ -4623,6 +4649,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:trusting")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var trustingData: Trusting? = null
         @MonsteraBuildSetter set
 
@@ -4642,6 +4669,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:giveable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var giveableData: Giveable? = null
         @MonsteraBuildSetter set
 
@@ -4660,6 +4688,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:water_movement")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var waterMovementData: WaterMovement? = null
         @MonsteraBuildSetter set
 
@@ -4679,6 +4708,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_sitting")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomSittingData: BehRandomSitting? = null
         @MonsteraBuildSetter set
 
@@ -4702,6 +4732,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.snacking")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSnackingData: BehSnacking? = null
         @MonsteraBuildSetter set
 
@@ -4724,6 +4755,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.roll")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRollData: BehRoll? = null
         @MonsteraBuildSetter set
 
@@ -4744,6 +4776,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.sneeze")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSneezeData: BehSneeze? = null
         @MonsteraBuildSetter set
 
@@ -4771,6 +4804,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.lay_down")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behLayDownData: BehLayDown? = null
         @MonsteraBuildSetter set
 
@@ -4792,6 +4826,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.scared")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behScaredData: BehScared? = null
         @MonsteraBuildSetter set
 
@@ -4812,6 +4847,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:on_friendly_anger")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onFriendlyAngerData: OnFriendlyAnger? = null
         @MonsteraBuildSetter set
 
@@ -4832,6 +4868,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:navigation.fly")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var navigationFlyData: NavigationComp? = null
         @MonsteraBuildSetter set
 
@@ -4852,6 +4889,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.fly")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementFlyData: MovementFly? = null
         @MonsteraBuildSetter set
 
@@ -4870,6 +4908,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_fly")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomFlyData: BehRandomFly? = null
         @MonsteraBuildSetter set
 
@@ -4895,6 +4934,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.follow_mob")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFollowMobData: BehFollowMob? = null
         @MonsteraBuildSetter set
 
@@ -4917,6 +4957,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:entity_sensor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var entitySensorData: EntitySensor? = null
         @MonsteraBuildSetter set
 
@@ -4940,6 +4981,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.glide")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementGlideData: MovementGlide? = null
         @MonsteraBuildSetter set
 
@@ -4960,6 +5002,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.swoop_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSwoopAttackData: BehSwoopAttack? = null
         @MonsteraBuildSetter set
 
@@ -4981,6 +5024,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.circle_around_anchor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behCircleAroundAnchorData: BehCircleAroundAnchor? = null
         @MonsteraBuildSetter set
 
@@ -5005,6 +5049,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:boostable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var boostableData: Boostable? = null
         @MonsteraBuildSetter set
 
@@ -5025,6 +5070,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:item_controllable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var itemControllableData: ItemControllable? = null
         @MonsteraBuildSetter set
 
@@ -5044,6 +5090,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.controlled_by_player")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behControlledByPlayerData: BehControlledByPlayer? = null
         @MonsteraBuildSetter set
 
@@ -5064,6 +5111,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:admire_item")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var admireItemData: AdmireItem? = null
         @MonsteraBuildSetter set
 
@@ -5084,6 +5132,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:annotation.open_door")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var annotationOpenDoorData: AnnotationOpenDoor? = null
         @MonsteraBuildSetter set
 
@@ -5102,6 +5151,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.admire_item")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behAdmireItemData: BehAdmireItem? = null
         @MonsteraBuildSetter set
 
@@ -5122,6 +5172,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.barter")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behBarterData: BehBarter? = null
         @MonsteraBuildSetter set
 
@@ -5141,6 +5192,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.charge_held_item")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behChargeHeldItemData: BehChargeHeldItem? = null
         @MonsteraBuildSetter set
 
@@ -5160,6 +5212,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:barter")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var barterData: Barter? = null
         @MonsteraBuildSetter set
 
@@ -5181,6 +5234,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:celebrate_hunt")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var celebrateHuntData: CelebrateHunt? = null
         @MonsteraBuildSetter set
 
@@ -5203,6 +5257,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_illager_captain")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isIllagerCaptainData: IsIllagerCaptain? = null
         @MonsteraBuildSetter set
 
@@ -5221,6 +5276,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.hold_ground")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behHoldGroundData: BehHoldGround? = null
         @MonsteraBuildSetter set
 
@@ -5243,6 +5299,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_to_random_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveToRandomBlockData: BehMoveToRandomBlock? = null
         @MonsteraBuildSetter set
 
@@ -5265,6 +5322,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.follow_target_captain")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFollowTargetCaptainData: BehFollowTargetCaptain? = null
         @MonsteraBuildSetter set
 
@@ -5287,6 +5345,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:exhaustion_values")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var exhaustionValuesData: ExhaustionValues? = null
         @MonsteraBuildSetter set
 
@@ -5314,6 +5373,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:player.saturation")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var playerSaturationData: PlayerSaturation? = null
         @MonsteraBuildSetter set
 
@@ -5334,6 +5394,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:player.exhaustion")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var playerExhaustionData: PlayerExhaustion? = null
         @MonsteraBuildSetter set
 
@@ -5354,6 +5415,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:player.level")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var playerLevelData: PlayerLevel? = null
         @MonsteraBuildSetter set
 
@@ -5374,6 +5436,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:player.experience")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var playerExperienceData: PlayerExperience? = null
         @MonsteraBuildSetter set
 
@@ -5394,6 +5457,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:insomnia")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var insomniaData: Insomnia? = null
         @MonsteraBuildSetter set
 
@@ -5413,6 +5477,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:spell_effects")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var spellEffectsData: SpellEffects? = null
         @MonsteraBuildSetter set
 
@@ -5432,6 +5497,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:raid_trigger")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var raidTriggerData: RaidTrigger? = null
         @MonsteraBuildSetter set
 
@@ -5450,6 +5516,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.stomp_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behStompAttackData: BehStompAttack? = null
         @MonsteraBuildSetter set
 
@@ -5473,6 +5540,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:mob_effect")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var mobEffectData: MobEffect? = null
         @MonsteraBuildSetter set
 
@@ -5495,6 +5563,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.skip")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementSkipData: MovementSkip? = null
         @MonsteraBuildSetter set
 
@@ -5513,6 +5582,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:jump.dynamic")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var jumpDynamicData: JumpDynamic? = null
         @MonsteraBuildSetter set
 
@@ -5531,6 +5601,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:ravager_blocked")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var ravagerBlockedData: RavagerBlocked? = null
         @MonsteraBuildSetter set
 
@@ -5550,6 +5621,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:break_blocks")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var breakBlocksData: BreakBlocks? = null
         @MonsteraBuildSetter set
 
@@ -5568,6 +5640,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.delayed_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDelayedAttackData: BehDelayedAttack? = null
         @MonsteraBuildSetter set
 
@@ -5595,6 +5668,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_stunned")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isStunnedData: IsStunned? = null
         @MonsteraBuildSetter set
 
@@ -5613,6 +5687,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.knockback_roar")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behKnockbackRoarData: BehKnockbackRoar? = null
         @MonsteraBuildSetter set
 
@@ -5639,6 +5714,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.eat_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEatBlockData: BehEatBlock? = null
         @MonsteraBuildSetter set
 
@@ -5660,6 +5736,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_sheared")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isShearedData: IsSheared? = null
         @MonsteraBuildSetter set
 
@@ -5678,6 +5755,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.silverfish_merge_with_stone")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSilverfishMergeWithStoneData: BehSilverfishMergeWithStone? = null
         @MonsteraBuildSetter set
 
@@ -5698,6 +5776,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.silverfish_wake_up_friends")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSilverfishWakeUpFriendsData: BehSilverfishWakeUpFriends? = null
         @MonsteraBuildSetter set
 
@@ -5717,6 +5796,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.skeleton_horse_trap")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSkeletonHorseTrapData: BehSkeletonHorseTrap? = null
         @MonsteraBuildSetter set
 
@@ -5738,6 +5818,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.slime_float")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSlimeFloatData: BehSlimeFloat? = null
         @MonsteraBuildSetter set
 
@@ -5759,6 +5840,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.slime_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSlimeAttackData: BehSlimeAttack? = null
         @MonsteraBuildSetter set
 
@@ -5778,6 +5860,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.slime_random_direction")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSlimeRandomDirectionData: BehSlimeRandomDirection? = null
         @MonsteraBuildSetter set
 
@@ -5800,6 +5883,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.slime_keep_on_jumping")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSlimeKeepOnJumpingData: BehSlimeKeepOnJumping? = null
         @MonsteraBuildSetter set
 
@@ -5820,6 +5904,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.timer_flag_1")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTimerFlag_1Data: BehTimerFlag_1? = null
         @MonsteraBuildSetter set
 
@@ -5840,6 +5925,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.timer_flag_3")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTimerFlag_3Data: BehTimerFlag_3? = null
         @MonsteraBuildSetter set
 
@@ -5860,6 +5946,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.timer_flag_2")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTimerFlag_2Data: BehTimerFlag_2? = null
         @MonsteraBuildSetter set
 
@@ -5880,6 +5967,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_pregnant")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isPregnantData: IsPregnant? = null
         @MonsteraBuildSetter set
 
@@ -5898,6 +5986,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_search_and_dig")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomSearchAndDigData: BehRandomSearchAndDig? = null
         @MonsteraBuildSetter set
 
@@ -5926,6 +6015,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:trail")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var trailData: Trail? = null
         @MonsteraBuildSetter set
 
@@ -5945,6 +6035,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:lava_movement")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var lavaMovementData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -5963,6 +6054,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.rise_to_liquid_level")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRiseToLiquidLevelData: BehRiseToLiquidLevel? = null
         @MonsteraBuildSetter set
 
@@ -5985,6 +6077,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_to_liquid")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveToLiquidData: BehMoveToLiquid? = null
         @MonsteraBuildSetter set
 
@@ -6009,6 +6102,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_ignited")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isIgnitedData: IsIgnited? = null
         @MonsteraBuildSetter set
 
@@ -6027,6 +6121,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:color2")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var color2Data: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -6045,6 +6140,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.charge_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behChargeAttackData: BehChargeAttack? = null
         @MonsteraBuildSetter set
 
@@ -6064,6 +6160,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.trade_with_player")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTradeWithPlayerData: BehTradeWithPlayer? = null
         @MonsteraBuildSetter set
 
@@ -6083,6 +6180,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.look_at_trading_player")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behLookAtTradingPlayerData: BehLookAtTradingPlayer? = null
         @MonsteraBuildSetter set
 
@@ -6102,6 +6200,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_indoors")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveIndoorsData: BehMoveIndoors? = null
         @MonsteraBuildSetter set
 
@@ -6123,6 +6222,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.restrict_open_door")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRestrictOpenDoorData: BehRestrictOpenDoor? = null
         @MonsteraBuildSetter set
 
@@ -6142,6 +6242,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.open_door")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behOpenDoorData: BehOpenDoor? = null
         @MonsteraBuildSetter set
 
@@ -6162,6 +6263,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.share_items")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behShareItemsData: BehShareItems? = null
         @MonsteraBuildSetter set
 
@@ -6184,6 +6286,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.celebrate_survive")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behCelebrateSurviveData: BehCelebrateSurvive? = null
         @MonsteraBuildSetter set
 
@@ -6204,6 +6307,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_outdoors")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveOutdoorsData: BehMoveOutdoors? = null
         @MonsteraBuildSetter set
 
@@ -6225,6 +6329,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.harvest_farm_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behHarvestFarmBlockData: BehHarvestFarmBlock? = null
         @MonsteraBuildSetter set
 
@@ -6245,6 +6350,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:trade_table")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var tradeTableData: TradeTable? = null
         @MonsteraBuildSetter set
 
@@ -6266,6 +6372,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.take_flower")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTakeFlowerData: BehTakeFlower? = null
         @MonsteraBuildSetter set
 
@@ -6285,6 +6392,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.play")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behPlayData: BehPlay? = null
         @MonsteraBuildSetter set
 
@@ -6305,6 +6413,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.make_love")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMakeLoveData: BehMakeLove? = null
         @MonsteraBuildSetter set
 
@@ -6324,6 +6433,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.receive_love")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behReceiveLoveData: BehReceiveLove? = null
         @MonsteraBuildSetter set
 
@@ -6343,6 +6453,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:hide")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var hideData: Hide? = null
         @MonsteraBuildSetter set
 
@@ -6361,6 +6472,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.hide")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behHideData: BehHide? = null
         @MonsteraBuildSetter set
 
@@ -6383,6 +6495,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:trade_resupply")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var tradeResupplyData: TradeResupply? = null
         @MonsteraBuildSetter set
 
@@ -6401,6 +6514,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.inspect_bookshelf")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behInspectBookshelfData: BehInspectBookshelf? = null
         @MonsteraBuildSetter set
 
@@ -6425,6 +6539,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.explore_outskirts")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behExploreOutskirtsData: BehExploreOutskirts? = null
         @MonsteraBuildSetter set
 
@@ -6454,6 +6569,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.work")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behWorkData: BehWork? = null
         @MonsteraBuildSetter set
 
@@ -6480,6 +6596,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.work_composter")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behWorkComposterData: BehWorkComposter? = null
         @MonsteraBuildSetter set
 
@@ -6504,6 +6621,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.mingle")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMingleData: BehMingle? = null
         @MonsteraBuildSetter set
 
@@ -6528,6 +6646,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.sleep")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSleepData: BehSleep? = null
         @MonsteraBuildSetter set
 
@@ -6553,6 +6672,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.fertilize_farm_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFertilizeFarmBlockData: BehFertilizeFarmBlock? = null
         @MonsteraBuildSetter set
 
@@ -6572,6 +6692,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.trade_interest")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTradeInterestData: BehTradeInterest? = null
         @MonsteraBuildSetter set
 
@@ -6596,6 +6717,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:economy_trade_table")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var economyTradeTableData: EconomyTradeTable? = null
         @MonsteraBuildSetter set
 
@@ -6618,6 +6740,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:skin_id")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var skinIdData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -6636,6 +6759,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.drink_potion")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDrinkPotionData: BehDrinkPotion? = null
         @MonsteraBuildSetter set
 
@@ -6656,6 +6780,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.drink_milk")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDrinkMilkData: BehDrinkMilk? = null
         @MonsteraBuildSetter set
 
@@ -6675,6 +6800,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:managed_wandering_trader")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var managedWanderingTraderData: ManagedWanderingTrader? = null
         @MonsteraBuildSetter set
 
@@ -6693,6 +6819,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement_sound_distance_offset")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementSoundDistanceOffsetData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -6711,6 +6838,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:vibration_damper")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var vibrationDamperData: VibrationDamper? = null
         @MonsteraBuildSetter set
 
@@ -6729,6 +6857,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:suspect_tracking")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var suspectTrackingData: SuspectTracking? = null
         @MonsteraBuildSetter set
 
@@ -6747,6 +6876,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:anger_level")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var angerLevelData: AngerLevel? = null
         @MonsteraBuildSetter set
 
@@ -6772,6 +6902,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:heartbeat")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var heartbeatData: Heartbeat? = null
         @MonsteraBuildSetter set
 
@@ -6791,6 +6922,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dig")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDigData: BehDig? = null
         @MonsteraBuildSetter set
 
@@ -6815,6 +6947,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.roar")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRoarData: BehRoar? = null
         @MonsteraBuildSetter set
 
@@ -6835,6 +6968,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.sonic_boom")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSonicBoomData: BehSonicBoom? = null
         @MonsteraBuildSetter set
 
@@ -6866,6 +7000,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.investigate_suspicious_location")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behInvestigateSuspiciousLocationData: BehInvestigateSuspiciousLocation? = null
         @MonsteraBuildSetter set
 
@@ -6887,6 +7022,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.sniff")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSniffData: BehSniff? = null
         @MonsteraBuildSetter set
 
@@ -6910,6 +7046,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.emerge")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEmergeData: BehEmerge? = null
         @MonsteraBuildSetter set
 
@@ -6929,6 +7066,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.wither_random_attack_pos_goal")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behWitherRandomAttackPosGoalData: BehWitherRandomAttackPosGoal? = null
         @MonsteraBuildSetter set
 
@@ -6949,6 +7087,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.wither_target_highest_damage")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behWitherTargetHighestDamageData: BehWitherTargetHighestDamage? = null
         @MonsteraBuildSetter set
 
@@ -6988,6 +7127,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.beg")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behBegData: BehBeg? = null
         @MonsteraBuildSetter set
 
@@ -7008,6 +7148,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.owner_hurt_by_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behOwnerHurtByTargetData: BehOwnerHurtByTarget? = null
         @MonsteraBuildSetter set
 
@@ -7027,6 +7168,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.owner_hurt_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behOwnerHurtTargetData: BehOwnerHurtTarget? = null
         @MonsteraBuildSetter set
 
@@ -7046,6 +7188,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:instant_despawn")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var instantDespawnData: InstantDespawn? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
@@ -1366,6 +1366,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:experience_reward")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var experienceRewardData: ExperienceReward? = null
         @MonsteraBuildSetter set
 
@@ -1386,6 +1387,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.breed")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behBreedData: BehBreed? = null
         @MonsteraBuildSetter set
 
@@ -1406,6 +1408,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:breedable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var breedableData: Breedable? = null
         @MonsteraBuildSetter set
 
@@ -1433,6 +1436,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:environment_sensor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var environmentSensorData: EnvironmentSensor? = null
         @MonsteraBuildSetter set
 
@@ -1451,6 +1455,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:damage_over_time")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var damageOverTimeData: DamageOverTime? = null
         @MonsteraBuildSetter set
 
@@ -1471,6 +1476,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:drying_out_timer")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var dryingOutTimerData: DryingOutTimer? = null
         @MonsteraBuildSetter set
 
@@ -1491,6 +1497,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:navigation.float")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var navigationFloatData: NavigationComp? = null
         @MonsteraBuildSetter set
 
@@ -1510,6 +1517,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.basic")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementBasicData: MovementBasic? = null
         @MonsteraBuildSetter set
 
@@ -1529,6 +1537,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.float_wander")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFloatWanderData: BehFloatWander? = null
         @MonsteraBuildSetter set
 
@@ -1553,6 +1562,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_towards_home_restriction")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveTowardsHomeRestrictionData: BehMoveTowardsHomeRestriction? = null
         @MonsteraBuildSetter set
 
@@ -1574,6 +1584,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:on_target_acquired")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onTargetAcquiredData: OnTargetAcquired? = null
         @MonsteraBuildSetter set
 
@@ -1594,6 +1605,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:home")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var homeData: Home? = null
         @MonsteraBuildSetter set
 
@@ -1613,6 +1625,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:block_sensor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var blockSensorData: BlockSensor? = null
         @MonsteraBuildSetter set
 
@@ -1632,6 +1645,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.hurt_by_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behHurtByTargetData: BehHurtByTarget? = null
         @MonsteraBuildSetter set
 
@@ -1653,6 +1667,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:angry")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var angryData: Angry? = null
         @MonsteraBuildSetter set
 
@@ -1678,6 +1693,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:mark_variant")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var markVariantData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -1696,6 +1712,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_to_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveToBlockData: BehMoveToBlock? = null
         @MonsteraBuildSetter set
 
@@ -1722,6 +1739,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:grows_crop")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var growsCropData: GrowsCrop? = null
         @MonsteraBuildSetter set
 
@@ -1742,6 +1760,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.go_home")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behGoHomeData: BehGoHome? = null
         @MonsteraBuildSetter set
 
@@ -1764,6 +1783,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:navigation.walk")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var navigationWalkData: NavigationComp? = null
         @MonsteraBuildSetter set
 
@@ -1796,6 +1816,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:can_climb")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var canClimbData: CanClimb? = null
         @MonsteraBuildSetter set
 
@@ -1814,6 +1835,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:fire_immune")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var fireImmuneData: FireImmune? = null
         @MonsteraBuildSetter set
 
@@ -1832,6 +1854,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:on_hurt")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onHurtData: OnHurt? = null
         @MonsteraBuildSetter set
 
@@ -1852,6 +1875,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:on_hurt_by_player")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onHurtByPlayerData: OnHurtByPlayer? = null
         @MonsteraBuildSetter set
 
@@ -1872,6 +1896,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:target_nearby_sensor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var targetNearbySensorData: TargetNearbySensor? = null
         @MonsteraBuildSetter set
 
@@ -1893,6 +1918,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:shooter")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var shooterData: Shooter? = null
         @MonsteraBuildSetter set
 
@@ -1917,6 +1943,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.ranged_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRangedAttackData: BehRangedAttack? = null
         @MonsteraBuildSetter set
 
@@ -1949,6 +1976,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_stackable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isStackableData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -1967,6 +1995,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:buoyant")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var buoyantData: Buoyant? = null
         @MonsteraBuildSetter set
 
@@ -1991,6 +2020,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:inside_block_notifier")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var insideBlockNotifierData: InsideBlockNotifier? = null
         @MonsteraBuildSetter set
 
@@ -2009,6 +2039,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:rideable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var rideableData: Rideable? = null
         @MonsteraBuildSetter set
 
@@ -2032,6 +2063,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:out_of_control")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var outOfControlData: OutOfControl? = null
         @MonsteraBuildSetter set
 
@@ -2050,6 +2082,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_tamed")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isTamedData: IsTamed? = null
         @MonsteraBuildSetter set
 
@@ -2068,6 +2101,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:healable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var healableData: Healable? = null
         @MonsteraBuildSetter set
 
@@ -2087,6 +2121,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_look_around_and_sit")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomLookAroundAndSitData: BehRandomLookAroundAndSit? = null
         @MonsteraBuildSetter set
 
@@ -2116,6 +2151,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:variable_max_auto_step")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var variableMaxAutoStepData: VariableMaxAutoStep? = null
         @MonsteraBuildSetter set
 
@@ -2137,6 +2173,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_saddled")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isSaddledData: IsSaddled? = null
         @MonsteraBuildSetter set
 
@@ -2155,6 +2192,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:input_ground_controlled")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var inputGroundControlledData: InputGroundControlled? = null
         @MonsteraBuildSetter set
 
@@ -2173,6 +2211,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:dash")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var dashData: Dash? = null
         @MonsteraBuildSetter set
 
@@ -2194,6 +2233,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.player_ride_tamed")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behPlayerRideTamedData: BehPlayerRideTamed? = null
         @MonsteraBuildSetter set
 
@@ -2212,6 +2252,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:equippable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var equippableData: Equippable? = null
         @MonsteraBuildSetter set
 
@@ -2230,6 +2271,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:attack_damage")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var attackDamageData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -2248,6 +2290,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:dweller")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var dwellerData: Dweller? = null
         @MonsteraBuildSetter set
 
@@ -2274,6 +2317,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.mount_pathing")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMountPathingData: BehMountPathing? = null
         @MonsteraBuildSetter set
 
@@ -2296,6 +2340,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.leap_at_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behLeapAtTargetData: BehLeapAtTarget? = null
         @MonsteraBuildSetter set
 
@@ -2318,6 +2363,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.ocelotattack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behOcelotattackData: BehOcelotattack? = null
         @MonsteraBuildSetter set
 
@@ -2347,6 +2393,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:tameable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var tameableData: Tameable? = null
         @MonsteraBuildSetter set
 
@@ -2366,6 +2413,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.avoid_mob_type")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behAvoidMobTypeData: BehAvoidMobType? = null
         @MonsteraBuildSetter set
 
@@ -2391,6 +2439,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_towards_dwelling_restriction")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveTowardsDwellingRestrictionData: BehMoveTowardsDwellingRestriction? = null
         @MonsteraBuildSetter set
 
@@ -2412,6 +2461,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:color")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var colorData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -2430,6 +2480,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:sittable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var sittableData: Sittable? = null
         @MonsteraBuildSetter set
 
@@ -2448,6 +2499,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_dyeable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isDyeableData: IsDyeable? = null
         @MonsteraBuildSetter set
 
@@ -2467,6 +2519,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.stay_while_sitting")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behStayWhileSittingData: BehStayWhileSitting? = null
         @MonsteraBuildSetter set
 
@@ -2486,6 +2539,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.ocelot_sit_on_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behOcelotSitOnBlockData: BehOcelotSitOnBlock? = null
         @MonsteraBuildSetter set
 
@@ -2506,6 +2560,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.pet_sleep_with_owner")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behPetSleepWithOwnerData: BehPetSleepWithOwner? = null
         @MonsteraBuildSetter set
 
@@ -2529,6 +2584,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:on_wake_with_owner")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onWakeWithOwnerData: OnWakeWithOwner? = null
         @MonsteraBuildSetter set
 
@@ -2549,6 +2605,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.drop_item_for")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDropItemForData: BehDropItemFor? = null
         @MonsteraBuildSetter set
 
@@ -2580,6 +2637,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:navigation.climb")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var navigationClimbData: NavigationComp? = null
         @MonsteraBuildSetter set
 
@@ -2599,6 +2657,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:addrider")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var addriderData: Addrider? = null
         @MonsteraBuildSetter set
 
@@ -2619,6 +2678,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:rail_movement")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var railMovementData: RailMovement? = null
         @MonsteraBuildSetter set
 
@@ -2637,6 +2697,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:spawn_entity")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var spawnEntityData: SpawnEntity? = null
         @MonsteraBuildSetter set
 
@@ -2655,6 +2716,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:rail_sensor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var railSensorData: RailSensor? = null
         @MonsteraBuildSetter set
 
@@ -2678,6 +2740,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.swell")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSwellData: BehSwell? = null
         @MonsteraBuildSetter set
 
@@ -2699,6 +2762,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.melee_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMeleeAttackData: BehMeleeAttack? = null
         @MonsteraBuildSetter set
 
@@ -2721,6 +2785,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:on_target_escape")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onTargetEscapeData: OnTargetEscape? = null
         @MonsteraBuildSetter set
 
@@ -2741,6 +2806,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:explode")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var explodeData: Explode? = null
         @MonsteraBuildSetter set
 
@@ -2766,6 +2832,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_charged")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isChargedData: IsCharged? = null
         @MonsteraBuildSetter set
 
@@ -2784,6 +2851,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.swim_with_entity")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSwimWithEntityData: BehSwimWithEntity? = null
         @MonsteraBuildSetter set
 
@@ -2812,6 +2880,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_breach")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomBreachData: BehRandomBreach? = null
         @MonsteraBuildSetter set
 
@@ -2834,6 +2903,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.find_underwater_treasure")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFindUnderwaterTreasureData: BehFindUnderwaterTreasure? = null
         @MonsteraBuildSetter set
 
@@ -2856,6 +2926,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:flocking")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var flockingData: Flocking? = null
         @MonsteraBuildSetter set
 
@@ -2892,6 +2963,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:bribeable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var bribeableData: Bribeable? = null
         @MonsteraBuildSetter set
 
@@ -2910,6 +2982,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:horse.jump_strength")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var horseJumpStrengthData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -2928,6 +3001,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:scale_by_age")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var scaleByAgeData: ScaleByAge? = null
         @MonsteraBuildSetter set
 
@@ -2948,6 +3022,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.run_around_like_crazy")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRunAroundLikeCrazyData: BehRunAroundLikeCrazy? = null
         @MonsteraBuildSetter set
 
@@ -2968,6 +3043,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:tamemount")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var tamemountData: Tamemount? = null
         @MonsteraBuildSetter set
 
@@ -2990,6 +3066,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:is_chested")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isChestedData: IsChested? = null
         @MonsteraBuildSetter set
 
@@ -3008,6 +3085,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:can_power_jump")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var canPowerJumpData: CanPowerJump? = null
         @MonsteraBuildSetter set
 
@@ -3026,6 +3104,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:equip_item")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var equipItemData: EquipItem? = null
         @MonsteraBuildSetter set
 
@@ -3044,6 +3123,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.generic")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementGenericData: MovementGeneric? = null
         @MonsteraBuildSetter set
 
@@ -3062,6 +3142,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:burns_in_daylight")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var burnsInDaylightData: BurnsInDaylight? = null
         @MonsteraBuildSetter set
 
@@ -3080,6 +3161,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:shareables")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var shareablesData: Shareables? = null
         @MonsteraBuildSetter set
 
@@ -3101,6 +3183,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.flee_sun")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFleeSunData: BehFleeSun? = null
         @MonsteraBuildSetter set
 
@@ -3121,6 +3204,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.equip_item")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEquipItemData: BehEquipItem? = null
         @MonsteraBuildSetter set
 
@@ -3140,6 +3224,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.stomp_turtle_egg")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behStompTurtleEggData: BehStompTurtleEgg? = null
         @MonsteraBuildSetter set
 
@@ -3164,6 +3249,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:equipment")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var equipmentData: Equipment? = null
         @MonsteraBuildSetter set
 
@@ -3183,6 +3269,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:annotation.break_door")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var annotationBreakDoorData: AnnotationBreakDoor? = null
         @MonsteraBuildSetter set
 
@@ -3203,6 +3290,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.sway")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementSwayData: MovementSway? = null
         @MonsteraBuildSetter set
 
@@ -3222,6 +3310,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.guardian_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behGuardianAttackData: BehGuardianAttack? = null
         @MonsteraBuildSetter set
 
@@ -3241,6 +3330,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:teleport")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var teleportData: Teleport? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
@@ -3354,6 +3354,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:lookat")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var lookatData: Lookat? = null
         @MonsteraBuildSetter set
 
@@ -3375,6 +3376,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.enderman_leave_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEndermanLeaveBlockData: BehEndermanLeaveBlock? = null
         @MonsteraBuildSetter set
 
@@ -3394,6 +3396,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.enderman_take_block")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEndermanTakeBlockData: BehEndermanTakeBlock? = null
         @MonsteraBuildSetter set
 
@@ -3413,6 +3416,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:block_climber")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var blockClimberData: BlockClimber? = null
         @MonsteraBuildSetter set
 
@@ -3431,6 +3435,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:boss")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var bossData: Boss? = null
         @MonsteraBuildSetter set
 
@@ -3451,6 +3456,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragonlanding")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragonlandingData: BehDragonlanding? = null
         @MonsteraBuildSetter set
 
@@ -3470,6 +3476,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragonflaming")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragonflamingData: BehDragonflaming? = null
         @MonsteraBuildSetter set
 
@@ -3489,6 +3496,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragonscanning")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragonscanningData: BehDragonscanning? = null
         @MonsteraBuildSetter set
 
@@ -3508,6 +3516,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragontakeoff")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragontakeoffData: BehDragontakeoff? = null
         @MonsteraBuildSetter set
 
@@ -3527,6 +3536,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragonchargeplayer")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragonchargeplayerData: BehDragonchargeplayer? = null
         @MonsteraBuildSetter set
 
@@ -3546,6 +3556,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragonstrafeplayer")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragonstrafeplayerData: BehDragonstrafeplayer? = null
         @MonsteraBuildSetter set
 
@@ -3565,6 +3576,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragonholdingpattern")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragonholdingpatternData: BehDragonholdingpattern? = null
         @MonsteraBuildSetter set
 
@@ -3584,6 +3596,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.dragondeath")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDragondeathData: BehDragondeath? = null
         @MonsteraBuildSetter set
 
@@ -3603,6 +3616,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.summon_entity")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSummonEntityData: BehSummonEntity? = null
         @MonsteraBuildSetter set
 
@@ -3622,6 +3636,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.send_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSendEventData: BehSendEvent? = null
         @MonsteraBuildSetter set
 
@@ -3641,6 +3656,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.look_at_entity")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behLookAtEntityData: BehLookAtEntity? = null
         @MonsteraBuildSetter set
 
@@ -3663,6 +3679,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:can_join_raid")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var canJoinRaidData: CanJoinRaid? = null
         @MonsteraBuildSetter set
 
@@ -3681,6 +3698,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.celebrate")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behCelebrateData: BehCelebrate? = null
         @MonsteraBuildSetter set
 
@@ -3702,6 +3720,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_to_village")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveToVillageData: BehMoveToVillage? = null
         @MonsteraBuildSetter set
 
@@ -3723,6 +3742,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.swim_wander")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSwimWanderData: BehSwimWander? = null
         @MonsteraBuildSetter set
 
@@ -3746,6 +3766,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.stalk_and_pounce_on_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behStalkAndPounceOnTargetData: BehStalkAndPounceOnTarget? = null
         @MonsteraBuildSetter set
 
@@ -3773,6 +3794,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.eat_carried_item")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEatCarriedItemData: BehEatCarriedItem? = null
         @MonsteraBuildSetter set
 
@@ -3793,6 +3815,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.raid_garden")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRaidGardenData: BehRaidGarden? = null
         @MonsteraBuildSetter set
 
@@ -3818,6 +3841,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:scheduler")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var schedulerData: Scheduler? = null
         @MonsteraBuildSetter set
 
@@ -3838,6 +3862,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:trust")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var trustData: Trust? = null
         @MonsteraBuildSetter set
 
@@ -3856,6 +3881,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.defend_trusted_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behDefendTrustedTargetData: BehDefendTrustedTarget? = null
         @MonsteraBuildSetter set
 
@@ -3879,6 +3905,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.nearest_prioritized_attackable_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behNearestPrioritizedAttackableTargetData: BehNearestPrioritizedAttackableTarget? = null
         @MonsteraBuildSetter set
 
@@ -3906,6 +3933,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.find_cover")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFindCoverData: BehFindCover? = null
         @MonsteraBuildSetter set
 
@@ -3927,6 +3955,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.nap")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behNapData: BehNap? = null
         @MonsteraBuildSetter set
 
@@ -3950,6 +3979,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.stroll_towards_village")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behStrollTowardsVillageData: BehStrollTowardsVillage? = null
         @MonsteraBuildSetter set
 
@@ -3974,6 +4004,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_to_land")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveToLandData: BehMoveToLand? = null
         @MonsteraBuildSetter set
 
@@ -3997,6 +4028,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.eat_mob")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behEatMobData: BehEatMob? = null
         @MonsteraBuildSetter set
 
@@ -4022,6 +4054,7 @@ open class Components : MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.croak")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behCroakData: BehCroak? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/Components.kt
@@ -2,14 +2,17 @@ package com.lop.devtools.monstera.files.beh.entitiy.components
 
 import com.lop.devtools.monstera.files.beh.entitiy.components.scraped.*
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.DebugMarker
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 
-open class Components: MonsteraRawFile() {
+open class Components : MonsteraRawFile() {
     @SerializedName("minecraft:is_hidden_when_invisible")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isHiddenWhenInvisibleData: IsHiddenWhenInvisible? = null
         @MonsteraBuildSetter set
 
@@ -28,6 +31,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:type_family")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var typeFamilyData: TypeFamily? = null
         @MonsteraBuildSetter set
 
@@ -44,8 +48,21 @@ open class Components: MonsteraRawFile() {
         typeFamilyData = (typeFamilyData ?: TypeFamily()).apply(value)
     }
 
+    fun typeFamily(vararg values: String) {
+        typeFamily {
+            family(values.toList())
+        }
+    }
+
+    fun familyType(vararg values: String) {
+        typeFamily {
+            family(values.toList())
+        }
+    }
+
     @SerializedName("minecraft:collision_box")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var collisionBoxData: CollisionBox? = null
         @MonsteraBuildSetter set
 
@@ -66,6 +83,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:balloonable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var balloonableData: Balloonable? = null
         @MonsteraBuildSetter set
 
@@ -85,6 +103,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:breathable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var breathableData: Breathable? = null
         @MonsteraBuildSetter set
 
@@ -110,6 +129,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:nameable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var nameableData: Nameable? = null
         @MonsteraBuildSetter set
 
@@ -130,6 +150,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:leashable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var leashableData: Leashable? = null
         @MonsteraBuildSetter set
 
@@ -152,6 +173,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:health")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var healthData: Health? = null
         @MonsteraBuildSetter set
 
@@ -172,6 +194,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:hurt_on_condition")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var hurtOnConditionData: HurtOnCondition? = null
         @MonsteraBuildSetter set
 
@@ -190,6 +213,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:damage_sensor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var damageSensorData: DamageSensor? = null
         @MonsteraBuildSetter set
 
@@ -208,6 +232,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:movement")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -226,6 +251,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:flying_speed")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var flyingSpeedData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -244,6 +270,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:navigation.hover")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var navigationHoverData: NavigationComp? = null
         @MonsteraBuildSetter set
 
@@ -269,6 +296,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.hover")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementHoverData: MovementHover? = null
         @MonsteraBuildSetter set
 
@@ -287,6 +315,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:follow_range")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var followRangeData: FollowRange? = null
         @MonsteraBuildSetter set
 
@@ -307,6 +336,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:ambient_sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var ambientSoundIntervalData: AmbientSoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -328,6 +358,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:jump.static")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var jumpStaticData: JumpStatic? = null
         @MonsteraBuildSetter set
 
@@ -347,6 +378,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:can_fly")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var canFlyData: CanFly? = null
         @MonsteraBuildSetter set
 
@@ -365,6 +397,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:physics")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var physicsData: Physics? = null
         @MonsteraBuildSetter set
 
@@ -386,6 +419,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:pushable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var pushableData: Pushable? = null
         @MonsteraBuildSetter set
 
@@ -406,6 +440,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:vibration_listener")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var vibrationListenerData: VibrationListener? = null
         @MonsteraBuildSetter set
 
@@ -424,6 +459,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:conditional_bandwidth_optimization")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var conditionalBandwidthOptimizationData: ConditionalBandwidthOptimization? = null
         @MonsteraBuildSetter set
 
@@ -443,6 +479,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:game_event_movement_tracking")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var gameEventMovementTrackingData: GameEventMovementTracking? = null
         @MonsteraBuildSetter set
 
@@ -464,6 +501,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:inventory")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var inventoryData: Inventory? = null
         @MonsteraBuildSetter set
 
@@ -487,6 +525,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:interact")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var interactData: Interact? = null
         @MonsteraBuildSetter set
 
@@ -517,6 +556,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.panic")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behPanicData: BehPanic? = null
         @MonsteraBuildSetter set
 
@@ -541,6 +581,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.go_and_give_items_to_noteblock")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behGoAndGiveItemsToNoteblockData: BehGoAndGiveItemsToNoteblock? = null
         @MonsteraBuildSetter set
 
@@ -563,6 +604,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.go_and_give_items_to_owner")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behGoAndGiveItemsToOwnerData: BehGoAndGiveItemsToOwner? = null
         @MonsteraBuildSetter set
 
@@ -584,6 +626,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.stay_near_noteblock")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behStayNearNoteblockData: BehStayNearNoteblock? = null
         @MonsteraBuildSetter set
 
@@ -606,6 +649,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.follow_owner")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFollowOwnerData: BehFollowOwner? = null
         @MonsteraBuildSetter set
 
@@ -630,6 +674,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.float")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFloatData: BehFloat? = null
         @MonsteraBuildSetter set
 
@@ -650,6 +695,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.look_at_player")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behLookAtPlayerData: BehLookAtPlayer? = null
         @MonsteraBuildSetter set
 
@@ -673,6 +719,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_look_around")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomLookAroundData: BehRandomLookAround? = null
         @MonsteraBuildSetter set
 
@@ -693,6 +740,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_hover")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomHoverData: BehRandomHover? = null
         @MonsteraBuildSetter set
 
@@ -716,6 +764,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:timer")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var timerData: Timer? = null
         @MonsteraBuildSetter set
 
@@ -737,6 +786,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.pickup_items")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behPickupItemsData: BehPickupItems? = null
         @MonsteraBuildSetter set
 
@@ -765,6 +815,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:knockback_resistance")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var knockbackResistanceData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -783,6 +834,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:loot")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var lootData: Loot? = null
         @MonsteraBuildSetter set
 
@@ -802,6 +854,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:persistent")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var persistentData: Persistent? = null
         @MonsteraBuildSetter set
 
@@ -820,6 +873,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:projectile")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var projectileData: Projectile? = null
         @MonsteraBuildSetter set
 
@@ -860,6 +914,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:navigation.generic")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var navigationGenericData: NavigationComp? = null
         @MonsteraBuildSetter set
 
@@ -888,6 +943,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:movement.amphibious")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var movementAmphibiousData: MovementAmphibious? = null
         @MonsteraBuildSetter set
 
@@ -907,6 +963,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:underwater_movement")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var underwaterMovementData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -925,6 +982,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:despawn")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var despawnData: Despawn? = null
         @MonsteraBuildSetter set
 
@@ -944,6 +1002,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var attackData: Attack? = null
         @MonsteraBuildSetter set
 
@@ -965,6 +1024,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:combat_regeneration")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var combatRegenerationData: CombatRegeneration? = null
         @MonsteraBuildSetter set
 
@@ -983,6 +1043,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.play_dead")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behPlayDeadData: BehPlayDead? = null
         @MonsteraBuildSetter set
 
@@ -1006,6 +1067,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.tempt")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behTemptData: BehTempt? = null
         @MonsteraBuildSetter set
 
@@ -1031,6 +1093,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.nearest_attackable_target")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behNearestAttackableTargetData: BehNearestAttackableTarget? = null
         @MonsteraBuildSetter set
 
@@ -1060,6 +1123,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.melee_box_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMeleeBoxAttackData: BehMeleeBoxAttack? = null
         @MonsteraBuildSetter set
 
@@ -1087,6 +1151,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.move_to_water")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behMoveToWaterData: BehMoveToWater? = null
         @MonsteraBuildSetter set
 
@@ -1110,6 +1175,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.swim_idle")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behSwimIdleData: BehSwimIdle? = null
         @MonsteraBuildSetter set
 
@@ -1131,6 +1197,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_swim")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomSwimData: BehRandomSwim? = null
         @MonsteraBuildSetter set
 
@@ -1155,6 +1222,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.random_stroll")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behRandomStrollData: BehRandomStroll? = null
         @MonsteraBuildSetter set
 
@@ -1178,6 +1246,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:attack_cooldown")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var attackCooldownData: AttackCooldown? = null
         @MonsteraBuildSetter set
 
@@ -1197,6 +1266,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:variant")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var variantData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -1215,6 +1285,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:is_baby")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var isBabyData: IsBaby? = null
         @MonsteraBuildSetter set
 
@@ -1233,6 +1304,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:scale")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var scaleData: ComponentValue? = null
         @MonsteraBuildSetter set
 
@@ -1251,6 +1323,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:ageable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var ageableData: Ageable? = null
         @MonsteraBuildSetter set
 
@@ -1272,6 +1345,7 @@ open class Components: MonsteraRawFile() {
 
     @SerializedName("minecraft:behavior.follow_parent")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var behFollowParentData: BehFollowParent? = null
         @MonsteraBuildSetter set
 
@@ -6904,7 +6978,7 @@ open class Components: MonsteraRawFile() {
         behFloatWander { }
         navigationFloat(navData)
         movement = speed
-        canFly {  }
+        canFly { }
         physics { }
         jumpStatic { }
     }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Addrider.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Addrider.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Addrider {
+class Addrider : MonsteraRawFile() {
 
     @SerializedName("entity_type")
     @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AdmireItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AdmireItem.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class AdmireItem {
+class AdmireItem : MonsteraRawFile() {
 
     @SerializedName("duration")
     @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Ageable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Ageable.kt
@@ -1,12 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Ageable {
+class Ageable : MonsteraRawFile() {
 
     @SerializedName("duration")
     @Expose
@@ -22,6 +25,7 @@ class Ageable {
 
     @SerializedName("grow_up")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var growUpData: GrowUp? = null
         @MonsteraBuildSetter set
 
@@ -49,7 +53,7 @@ class Ageable {
         dropItemsData = (dropItemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
 
-    class GrowUp {
+    class GrowUp : MonsteraRawFile() {
 
         @SerializedName("event")
         @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AmbientSoundInterval.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AmbientSoundInterval.kt
@@ -1,12 +1,14 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class AmbientSoundInterval {
-
+class AmbientSoundInterval : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null
@@ -21,6 +23,7 @@ class AmbientSoundInterval {
 
     @SerializedName("event_names")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var eventNamesData: MutableList<EventNames>? = null
         @MonsteraBuildSetter set
 
@@ -40,7 +43,7 @@ class AmbientSoundInterval {
         eventNamesData = (eventNamesData ?: mutableListOf()).also { it.add(EventNames().apply(value)) }
     }
 
-    class EventNames {
+    class EventNames : MonsteraRawFile() {
         @SerializedName("event_name")
         @Expose
         var eventName: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AngerLevel.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AngerLevel.kt
@@ -1,13 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class AngerLevel {
-
+class AngerLevel : MonsteraRawFile() {
     @SerializedName("max_anger")
     @Expose
     var maxAnger: Number? = null
@@ -39,6 +41,7 @@ class AngerLevel {
 
     @SerializedName("on_increase_sounds")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onIncreaseSoundsData: MutableList<OnIncreaseSounds>? = null
         @MonsteraBuildSetter set
         
@@ -77,7 +80,7 @@ class AngerLevel {
         nuisanceFilterData = (nuisanceFilterData ?: BehEntityFilter()).apply(value)
     }
 
-    class OnIncreaseSounds {
+    class OnIncreaseSounds : MonsteraRawFile() {
         @SerializedName("sound")
         @Expose
         var sound: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Angry.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Angry.kt
@@ -1,14 +1,16 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Angry {
-
+class Angry : MonsteraRawFile() {
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
@@ -20,7 +22,6 @@ class Angry {
     @SerializedName("broadcastRange")
     @Expose
     var broadcastRange: Number? = null
-
 
     @SerializedName("broadcast_filters")
     @Expose
@@ -45,6 +46,7 @@ class Angry {
 
     @SerializedName("calm_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var calmEventData: CalmEvent? = null
         @MonsteraBuildSetter set
 
@@ -67,14 +69,13 @@ class Angry {
     @Expose
     var durationDelta: Number? = null
 
-
     @SerializedName("angry_sound")
     @Expose
     var angrySound: String? = null
 
-
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -97,16 +98,13 @@ class Angry {
     @Expose
     var broadcastAngerOnAttack: Boolean? = null
 
-
     @SerializedName("broadcast_anger_on_being_attacked")
     @Expose
     var broadcastAngerOnBeingAttacked: Boolean? = null
 
-
     @SerializedName("broadcast_targets")
     @Expose
     var broadcastTargetsData: MutableList<String>? = null
-
 
     @OptIn(MonsteraBuildSetter::class)
     @Components.VanillaComponentMarker
@@ -132,29 +130,23 @@ class Angry {
         filtersData = (filtersData ?: BehEntityFilter()).apply(value)
     }
 
-    class CalmEvent {
-
+    class CalmEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
 
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-
     }
 
-    class SoundInterval {
-
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
 
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AnnotationBreakDoor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AnnotationBreakDoor.kt
@@ -2,17 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class AnnotationBreakDoor {
-
+class AnnotationBreakDoor : MonsteraRawFile() {
     @SerializedName("break_time")
     @Expose
     var breakTime: Number? = null
         
-
     @SerializedName("min_difficulty")
     @Expose
     var minDifficulty: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AnnotationOpenDoor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AnnotationOpenDoor.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class AnnotationOpenDoor
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class AnnotationOpenDoor : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AreaAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AreaAttack.kt
@@ -3,30 +3,27 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class AreaAttack {
+class AreaAttack : MonsteraRawFile() {
     @SerializedName("damage_range")
     @Expose
     var damageRange: Number? = null
         
-
     @SerializedName("damage_per_tick")
     @Expose
     var damagePerTick: Number? = null
         
-
     @SerializedName("damage_cooldown")
     @Expose
     var damageCooldown: Number? = null
         
-
     @SerializedName("cause")
     @Expose
     var cause: String? = null
         
-
     @SerializedName("entity_filter")
     @Expose
     var entityFilterData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Attack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Attack.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Attack {
+class Attack : MonsteraRawFile() {
     @SerializedName("damage")
     @Expose
     var damage: Number? = null
-        
 
     @SerializedName("effect_name")
     @Expose
     var effectName: String? = null
-        
 
     @SerializedName("effect_duration")
     @Expose
     var effectDuration: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AttackCooldown.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/AttackCooldown.kt
@@ -1,12 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class AttackCooldown {
+class AttackCooldown : MonsteraRawFile() {
     @SerializedName("attack_cooldown_time")
     @Expose
     var attackCooldownTime: Number? = null
@@ -14,6 +17,7 @@ class AttackCooldown {
 
     @SerializedName("attack_cooldown_complete_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var attackCooldownCompleteEventData: AttackCooldownCompleteEvent? = null
         @MonsteraBuildSetter set
 
@@ -33,7 +37,7 @@ class AttackCooldown {
             (attackCooldownCompleteEventData ?: AttackCooldownCompleteEvent()).apply(value)
     }
 
-    class AttackCooldownCompleteEvent {
+    class AttackCooldownCompleteEvent : MonsteraRawFile() {
 
         @SerializedName("event")
         @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Balloonable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Balloonable.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Balloonable {
-
+class Balloonable: MonsteraRawFile() {
     @SerializedName("mass")
     @Expose
     var mass: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Barter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Barter.kt
@@ -2,11 +2,12 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables
 import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables.Companion.resolveRelative
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class Barter {
+class Barter : MonsteraRawFile() {
 
     @SerializedName("barter_table")
     @Expose
@@ -26,5 +27,4 @@ class Barter {
     @SerializedName("cooldown_after_being_attacked")
     @Expose
     var cooldownAfterBeingAttacked: Number? = null
-
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehAdmireItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehAdmireItem.kt
@@ -1,25 +1,26 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehAdmireItem {
-
+class BehAdmireItem : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("admire_item_sound")
     @Expose
     var admireItemSound: String? = null
         
-
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -40,6 +41,7 @@ class BehAdmireItem {
 
     @SerializedName("on_admire_item_start")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onAdmireItemStartData: OnAdmireItemStart? = null
         @MonsteraBuildSetter set
 
@@ -60,6 +62,7 @@ class BehAdmireItem {
 
     @SerializedName("on_admire_item_stop")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onAdmireItemStopData: OnAdmireItemStop? = null
         @MonsteraBuildSetter set
 
@@ -78,42 +81,33 @@ class BehAdmireItem {
         onAdmireItemStopData = (onAdmireItemStopData ?: OnAdmireItemStop()).apply(value)
     }
 
-    class SoundInterval {
-
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
-            
 
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class OnAdmireItemStart {
-
+    class OnAdmireItemStart : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnAdmireItemStop {
-
+    class OnAdmireItemStop : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehAvoidBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehAvoidBlock.kt
@@ -1,49 +1,47 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehAvoidBlock {
+class BehAvoidBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("tick_interval")
     @Expose
     var tickInterval: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("walk_speed_modifier")
     @Expose
     var walkSpeedModifier: Number? = null
         
-
     @SerializedName("sprint_speed_modifier")
     @Expose
     var sprintSpeedModifier: Number? = null
         
-
     @SerializedName("avoid_block_sound")
     @Expose
     var avoidBlockSound: String? = null
         
-
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -80,6 +78,7 @@ class BehAvoidBlock {
 
     @SerializedName("on_escape")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onEscapeData: MutableList<OnEscape>? = null
         @MonsteraBuildSetter set
 
@@ -98,29 +97,23 @@ class BehAvoidBlock {
         onEscapeData = (onEscapeData ?: mutableListOf()).also { it.add(OnEscape().apply(value)) }
     }
 
-    class SoundInterval {
-
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
-            
 
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class OnEscape {
-
+    class OnEscape : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehAvoidMobType.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehAvoidMobType.kt
@@ -1,21 +1,24 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehAvoidMobType {
-
+class BehAvoidMobType : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 
@@ -39,19 +42,17 @@ class BehAvoidMobType {
     @Expose
     var probabilityPerStrength: Number? = null
         
-
     @SerializedName("remove_target")
     @Expose
     var removeTarget: Boolean? = null
         
-
     @SerializedName("avoid_mob_sound")
     @Expose
     var avoidMobSound: String? = null
         
-
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -105,27 +106,23 @@ class BehAvoidMobType {
         onEscapeEventData = (onEscapeEventData ?: OnEscapeEvent()).apply(value)
     }
 
-    class SoundInterval {
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
             
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class OnEscapeEvent {
+    class OnEscapeEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehBarter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehBarter.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehBarter {
-
+class BehBarter : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehBeg.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehBeg.kt
@@ -3,23 +3,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehBeg {
+class BehBeg : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("look_distance")
     @Expose
     var lookDistance: Number? = null
         
-
     @SerializedName("look_time")
     @Expose
     var lookTimeData: MutableList<Number>? = null
-
+        @MonsteraBuildSetter set
 
     @OptIn(MonsteraBuildSetter::class)
     @Components.VanillaComponentMarker
@@ -30,6 +29,7 @@ class BehBeg {
     @SerializedName("items")
     @Expose
     var itemsData: MutableList<String>? = null
+        @MonsteraBuildSetter set
         
 
     @OptIn(MonsteraBuildSetter::class)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehBreed.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehBreed.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehBreed {
+class BehBreed : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehCelebrate.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehCelebrate.kt
@@ -1,24 +1,26 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehCelebrate {
+class BehCelebrate : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("celebration_sound")
     @Expose
     var celebrationSound: String? = null
         
-
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -39,6 +41,7 @@ class BehCelebrate {
 
     @SerializedName("jump_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var jumpIntervalData: JumpInterval? = null
         @MonsteraBuildSetter set
 
@@ -61,9 +64,9 @@ class BehCelebrate {
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("on_celebration_end_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onCelebrationEndEventData: OnCelebrationEndEvent? = null
         @MonsteraBuildSetter set
 
@@ -82,39 +85,33 @@ class BehCelebrate {
         onCelebrationEndEventData = (onCelebrationEndEventData ?: OnCelebrationEndEvent()).apply(value)
     }
 
-    class SoundInterval {
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
             
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class JumpInterval {
+    class JumpInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
             
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class OnCelebrationEndEvent {
+    class OnCelebrationEndEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehCelebrateSurvive.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehCelebrateSurvive.kt
@@ -1,19 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehCelebrateSurvive {
+class BehCelebrateSurvive : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("fireworks_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var fireworksIntervalData: FireworksInterval? = null
         @MonsteraBuildSetter set
 
@@ -39,6 +42,7 @@ class BehCelebrateSurvive {
 
     @SerializedName("on_celebration_end_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onCelebrationEndEventData: OnCelebrationEndEvent? = null
         @MonsteraBuildSetter set
 
@@ -57,27 +61,23 @@ class BehCelebrateSurvive {
         onCelebrationEndEventData = (onCelebrationEndEventData ?: OnCelebrationEndEvent()).apply(value)
     }
 
-    class FireworksInterval {
+    class FireworksInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
             
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class OnCelebrationEndEvent {
+    class OnCelebrationEndEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehChargeAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehChargeAttack.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehChargeAttack {
+class BehChargeAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehChargeHeldItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehChargeHeldItem.kt
@@ -2,10 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
-import com.lop.devtools.monstera.files.beh.entitiy.components.Components
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehChargeHeldItem {
+class BehChargeHeldItem : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehCircleAroundAnchor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehCircleAroundAnchor.kt
@@ -2,40 +2,33 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
-import com.lop.devtools.monstera.files.beh.entitiy.components.Components
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehCircleAroundAnchor {
+class BehCircleAroundAnchor : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("radius_change")
     @Expose
     var radiusChange: Number? = null
         
-
     @SerializedName("radius_adjustment_chance")
     @Expose
     var radiusAdjustmentChance: Number? = null
         
-
     @SerializedName("height_adjustment_chance")
     @Expose
     var heightAdjustmentChance: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("angle_change")
     @Expose
     var angleChange: Number? = null
         
-
     @SerializedName("radius_range")
     @Expose
     var radiusRangeData: MutableList<Number>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehControlledByPlayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehControlledByPlayer.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehControlledByPlayer {
+class BehControlledByPlayer : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("mount_speed_multiplier")
     @Expose
     var mountSpeedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDefendTrustedTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDefendTrustedTarget.kt
@@ -1,39 +1,38 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehDefendTrustedTarget {
+class BehDefendTrustedTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
         
-
     @SerializedName("must_see")
     @Expose
     var mustSee: Boolean? = null
         
-
     @SerializedName("aggro_sound")
     @Expose
     var aggroSound: String? = null
         
-
     @SerializedName("sound_chance")
     @Expose
     var soundChance: Number? = null
         
-
     @SerializedName("on_defend_start")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onDefendStartData: OnDefendStart? = null
         @MonsteraBuildSetter set
 
@@ -52,15 +51,13 @@ class BehDefendTrustedTarget {
         onDefendStartData = (onDefendStartData ?: OnDefendStart()).apply(value)
     }
 
-    class OnDefendStart {
+    class OnDefendStart : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDefendVillageTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDefendVillageTarget.kt
@@ -1,29 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehDefendVillageTarget {
+class BehDefendVillageTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("must_reach")
     @Expose
     var mustReach: Boolean? = null
         
-
     @SerializedName("attack_chance")
     @Expose
     var attackChance: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: BehEntityTypes? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDelayedAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDelayedAttack.kt
@@ -2,52 +2,42 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDelayedAttack {
-
+class BehDelayedAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("attack_once")
     @Expose
     var attackOnce: Boolean? = null
         
-
     @SerializedName("track_target")
     @Expose
     var trackTarget: Boolean? = null
         
-
     @SerializedName("require_complete_path")
     @Expose
     var requireCompletePath: Boolean? = null
         
-
     @SerializedName("random_stop_interval")
     @Expose
     var randomStopInterval: Number? = null
         
-
     @SerializedName("reach_multiplier")
     @Expose
     var reachMultiplier: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("attack_duration")
     @Expose
     var attackDuration: Number? = null
         
-
     @SerializedName("hit_delay_pct")
     @Expose
     var hitDelayPct: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDig.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDig.kt
@@ -1,44 +1,42 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehDig {
+class BehDig : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("idle_time")
     @Expose
     var idleTime: Number? = null
         
-
     @SerializedName("vibration_is_disturbance")
     @Expose
     var vibrationIsDisturbance: Boolean? = null
         
-
     @SerializedName("suspicion_is_disturbance")
     @Expose
     var suspicionIsDisturbance: Boolean? = null
         
-
     @SerializedName("digs_in_daylight")
     @Expose
     var digsInDaylight: Boolean? = null
         
-
     @SerializedName("on_start")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onStartData: OnStart? = null
         @MonsteraBuildSetter set
 
@@ -57,15 +55,13 @@ class BehDig {
         onStartData = (onStartData ?: OnStart()).apply(value)
     }
 
-    class OnStart {
+    class OnStart : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonchargeplayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonchargeplayer.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragonchargeplayer {
+class BehDragonchargeplayer : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragondeath.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragondeath.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragondeath {
+class BehDragondeath : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonflaming.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonflaming.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragonflaming {
+class BehDragonflaming : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonholdingpattern.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonholdingpattern.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragonholdingpattern {
+class BehDragonholdingpattern : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonlanding.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonlanding.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragonlanding {
+class BehDragonlanding : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonscanning.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonscanning.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragonscanning {
+class BehDragonscanning : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonstrafeplayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragonstrafeplayer.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragonstrafeplayer {
+class BehDragonstrafeplayer : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragontakeoff.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDragontakeoff.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehDragontakeoff {
+class BehDragontakeoff : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDrinkMilk.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDrinkMilk.kt
@@ -3,15 +3,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehDrinkMilk {
+class BehDrinkMilk : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDrinkPotion.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDrinkPotion.kt
@@ -1,12 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehDrinkPotion {
+class BehDrinkPotion : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
@@ -19,6 +22,7 @@ class BehDrinkPotion {
 
     @SerializedName("potions")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var potionsData: MutableList<Potions>? = null
         @MonsteraBuildSetter set
 
@@ -37,18 +41,15 @@ class BehDrinkPotion {
         potionsData = (potionsData ?: mutableListOf()).also { it.add(Potions().apply(value)) }
     }
 
-    class Potions {
-
+    class Potions : MonsteraRawFile() {
         @SerializedName("id")
         @Expose
         var id: Number? = null
             
-
         @SerializedName("chance")
         @Expose
         var chance: Number? = null
             
-
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDropItemFor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehDropItemFor.kt
@@ -1,48 +1,44 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehDropItemFor {
+class BehDropItemFor : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("seconds_before_pickup")
     @Expose
     var secondsBeforePickup: Number? = null
         
-
     @SerializedName("cooldown")
     @Expose
     var cooldown: Number? = null
         
-
     @SerializedName("drop_item_chance")
     @Expose
     var dropItemChance: Number? = null
         
-
     @SerializedName("offering_distance")
     @Expose
     var offeringDistance: Number? = null
-        
 
     @SerializedName("minimum_teleport_distance")
     @Expose
     var minimumTeleportDistance: Number? = null
         
-
     @SerializedName("max_head_look_at_height")
     @Expose
     var maxHeadLookAtHeight: Number? = null
         
-
     @SerializedName("target_range")
     @Expose
     var targetRangeData: MutableList<Number>? = null
@@ -71,29 +67,25 @@ class BehDropItemFor {
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
-        
 
     @SerializedName("search_count")
     @Expose
     var searchCount: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 
@@ -118,6 +110,7 @@ class BehDropItemFor {
 
     @SerializedName("on_drop_attempt")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onDropAttemptData: OnDropAttempt? = null
         @MonsteraBuildSetter set
 
@@ -136,7 +129,7 @@ class BehDropItemFor {
         onDropAttemptData = (onDropAttemptData ?: OnDropAttempt()).apply(value)
     }
 
-    class OnDropAttempt {
+    class OnDropAttempt : MonsteraRawFile() {
 
         @SerializedName("event")
         @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEatBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEatBlock.kt
@@ -1,29 +1,31 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehEatBlock {
+class BehEatBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("success_chance")
     @Expose
     var successChance: String? = null
         
-
     @SerializedName("time_until_eat")
     @Expose
     var timeUntilEat: Number? = null
         
-
     @SerializedName("eat_and_replace_block_pairs")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var eatAndReplaceBlockPairsData: MutableList<EatAndReplaceBlockPairs>? = null
         @MonsteraBuildSetter set
 
@@ -45,6 +47,7 @@ class BehEatBlock {
 
     @SerializedName("on_eat")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onEatData: OnEat? = null
         @MonsteraBuildSetter set
 
@@ -63,27 +66,23 @@ class BehEatBlock {
         onEatData = (onEatData ?: OnEat()).apply(value)
     }
 
-    class EatAndReplaceBlockPairs {
+    class EatAndReplaceBlockPairs : MonsteraRawFile() {
         @SerializedName("eat_block")
         @Expose
         var eatBlock: String? = null
             
-
         @SerializedName("replace_block")
         @Expose
         var replaceBlock: String? = null
-            
     }
 
-    class OnEat {
+    class OnEat : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEatCarriedItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEatCarriedItem.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEatCarriedItem {
+class BehEatCarriedItem : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEatMob.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEatMob.kt
@@ -3,40 +3,34 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEatMob {
+class BehEatMob : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("run_speed")
     @Expose
     var runSpeed: Number? = null
         
-
     @SerializedName("eat_animation_time")
     @Expose
     var eatAnimationTime: Number? = null
         
-
     @SerializedName("pull_in_force")
     @Expose
     var pullInForce: Number? = null
         
-
     @SerializedName("reach_mob_distance")
     @Expose
     var reachMobDistance: Number? = null
         
-
     @SerializedName("eat_mob_sound")
     @Expose
     var eatMobSound: String? = null
         
-
     @SerializedName("loot_table")
     @Expose
     var lootTable: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEmerge.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEmerge.kt
@@ -1,19 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehEmerge {
+class BehEmerge : MonsteraRawFile() {
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("on_done")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onDoneData: OnDone? = null
         @MonsteraBuildSetter set
 
@@ -32,15 +35,13 @@ class BehEmerge {
         onDoneData = (onDoneData ?: OnDone()).apply(value)
     }
 
-    class OnDone {
+    class OnDone : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEndermanLeaveBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEndermanLeaveBlock.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEndermanLeaveBlock {
+class BehEndermanLeaveBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEndermanTakeBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEndermanTakeBlock.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEndermanTakeBlock {
+class BehEndermanTakeBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEquipItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehEquipItem.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEquipItem {
+class BehEquipItem : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehExploreOutskirts.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehExploreOutskirts.kt
@@ -2,65 +2,53 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
-import com.lop.devtools.monstera.files.beh.entitiy.components.Components
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehExploreOutskirts {
+class BehExploreOutskirts : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("next_xz")
     @Expose
     var nextXz: Number? = null
         
-
     @SerializedName("next_y")
     @Expose
     var nextY: Number? = null
         
-
     @SerializedName("min_wait_time")
     @Expose
     var minWaitTime: Number? = null
         
-
     @SerializedName("max_wait_time")
     @Expose
     var maxWaitTime: Number? = null
-        
 
     @SerializedName("max_travel_time")
     @Expose
     var maxTravelTime: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("explore_dist")
     @Expose
     var exploreDist: Number? = null
         
-
     @SerializedName("min_perimeter")
     @Expose
     var minPerimeter: Number? = null
         
-
     @SerializedName("min_dist_from_target")
     @Expose
     var minDistFromTarget: Number? = null
         
-
     @SerializedName("timer_ratio")
     @Expose
     var timerRatio: Number? = null
         
-
     @SerializedName("dist_from_boundary")
     @Expose
     var distFromBoundaryData: MutableList<Number>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFertilizeFarmBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFertilizeFarmBlock.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFertilizeFarmBlock {
+class BehFertilizeFarmBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFindCover.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFindCover.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFindCover {
+class BehFindCover : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFindMount.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFindMount.kt
@@ -3,40 +3,34 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFindMount {
+class BehFindMount : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
         
-
     @SerializedName("avoid_water")
     @Expose
     var avoidWater: Boolean? = null
         
-
     @SerializedName("start_delay")
     @Expose
     var startDelay: Number? = null
         
-
     @SerializedName("target_needed")
     @Expose
     var targetNeeded: Boolean? = null
         
-
     @SerializedName("mount_distance")
     @Expose
     var mountDistance: Number? = null
         
-
     @SerializedName("max_failed_attempts")
     @Expose
     var maxFailedAttempts: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFleeSun.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFleeSun.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFleeSun {
+class BehFleeSun : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFloat.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFloat.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFloat {
+class BehFloat : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("sink_with_passengers")
     @Expose
     var sinkWithPassengers: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFloatWander.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFloatWander.kt
@@ -2,30 +2,25 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
-import com.lop.devtools.monstera.files.beh.entitiy.components.Components
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFloatWander {
+class BehFloatWander : MonsteraRawFile() {
     @SerializedName("xz_dist")
     @Expose
     var xzDist: Number? = null
         
-
     @SerializedName("y_dist")
     @Expose
     var yDist: Number? = null
         
-
     @SerializedName("y_offset")
     @Expose
     var yOffset: Number? = null
         
-
     @SerializedName("random_reselect")
     @Expose
     var randomReselect: Boolean? = null
         
-
     @SerializedName("float_duration")
     @Expose
     var floatDurationData: MutableList<Number>? = null
@@ -38,9 +33,7 @@ class BehFloatWander {
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("must_reach")
     @Expose
     var mustReach: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowCaravan.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowCaravan.kt
@@ -1,29 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehFollowCaravan {
+class BehFollowCaravan : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("entity_count")
     @Expose
     var entityCount: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: BehEntityTypes? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowMob.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowMob.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFollowMob {
+class BehFollowMob : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("stop_distance")
     @Expose
     var stopDistance: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowOwner.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowOwner.kt
@@ -2,36 +2,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFollowOwner {
+class BehFollowOwner : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("start_distance")
     @Expose
     var startDistance: Number? = null
-        
 
     @SerializedName("stop_distance")
     @Expose
     var stopDistance: Number? = null
-        
 
     @SerializedName("can_teleport")
     @Expose
     var canTeleport: Boolean? = null
-        
 
     @SerializedName("ignore_vibration")
     @Expose
     var ignoreVibration: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowParent.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowParent.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFollowParent {
+class BehFollowParent : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowTargetCaptain.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehFollowTargetCaptain.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehFollowTargetCaptain {
+class BehFollowTargetCaptain : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
-        
 
     @SerializedName("follow_distance")
     @Expose
     var followDistance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGoAndGiveItemsToNoteblock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGoAndGiveItemsToNoteblock.kt
@@ -1,29 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehGoAndGiveItemsToNoteblock {
+class BehGoAndGiveItemsToNoteblock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("run_speed")
     @Expose
     var runSpeed: Number? = null
-        
 
     @SerializedName("throw_sound")
     @Expose
     var throwSound: String? = null
-        
 
     @SerializedName("on_item_throw")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onItemThrowData: MutableList<OnItemThrow>? = null
         @MonsteraBuildSetter set
 
@@ -42,15 +43,13 @@ class BehGoAndGiveItemsToNoteblock {
         onItemThrowData = (onItemThrowData ?: mutableListOf()).also { it.add(OnItemThrow().apply(value)) }
     }
 
-    class OnItemThrow {
+    class OnItemThrow : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGoAndGiveItemsToOwner.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGoAndGiveItemsToOwner.kt
@@ -1,29 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehGoAndGiveItemsToOwner {
+class BehGoAndGiveItemsToOwner : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("run_speed")
     @Expose
     var runSpeed: Number? = null
         
-
     @SerializedName("throw_sound")
     @Expose
     var throwSound: String? = null
         
-
     @SerializedName("on_item_throw")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onItemThrowData: MutableList<OnItemThrow>? = null
         @MonsteraBuildSetter set
 
@@ -42,15 +43,13 @@ class BehGoAndGiveItemsToOwner {
         onItemThrowData = (onItemThrowData ?: mutableListOf()).also { it.add(OnItemThrow().apply(value)) }
     }
 
-    class OnItemThrow {
+    class OnItemThrow : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGoHome.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGoHome.kt
@@ -1,35 +1,35 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehGoHome {
+class BehGoHome : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("on_home")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onHomeData: MutableList<OnHome>? = null
         @MonsteraBuildSetter set
 
@@ -50,6 +50,7 @@ class BehGoHome {
 
     @SerializedName("on_failed")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onFailedData: MutableList<OnFailed>? = null
         @MonsteraBuildSetter set
 
@@ -68,12 +69,11 @@ class BehGoHome {
         onFailedData = (onFailedData ?: mutableListOf()).also { it.add(OnFailed().apply(value)) }
     }
 
-    class OnHome {
+    class OnHome : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null
             
-
         /**
          * com.lop.devtools.monstera.files.beh.entitiy.components.scraped.com.lop.devtools.monstera.files.beh.entitiy.components.scraped.com.lop.devtools.monstera.files.beh.entitiy.components.scraped.com.lop.devtools.monstera.files.beh.entitiy.components.scraped.Filters allow data objects to specify test criteria which allows their use.
          * ```
@@ -91,23 +91,18 @@ class BehGoHome {
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnFailed {
-
+    class OnFailed : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGuardianAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehGuardianAttack.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehGuardianAttack {
-
+class BehGuardianAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHarvestFarmBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHarvestFarmBlock.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehHarvestFarmBlock {
+class BehHarvestFarmBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHide.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHide.kt
@@ -3,25 +3,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehHide {
+class BehHide : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("poi_type")
     @Expose
     var poiType: String? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHoldGround.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHoldGround.kt
@@ -1,34 +1,34 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehHoldGround {
+class BehHoldGround : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("min_radius")
     @Expose
     var minRadius: Number? = null
         
-
     @SerializedName("broadcast")
     @Expose
     var broadcast: Boolean? = null
         
-
     @SerializedName("broadcast_range")
     @Expose
     var broadcastRange: Number? = null
         
-
     @SerializedName("within_radius_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var withinRadiusEventData: WithinRadiusEvent? = null
         @MonsteraBuildSetter set
 
@@ -47,15 +47,13 @@ class BehHoldGround {
         withinRadiusEventData = (withinRadiusEventData ?: WithinRadiusEvent()).apply(value)
     }
 
-    class WithinRadiusEvent {
+    class WithinRadiusEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHurtByTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehHurtByTarget.kt
@@ -1,19 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehHurtByTarget {
+class BehHurtByTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var entityTypesData: BehEntityTypes? = null
         @MonsteraBuildSetter set
 
@@ -34,7 +37,6 @@ class BehHurtByTarget {
     @Expose
     var hurtOwner: Boolean? = null
         
-
     @SerializedName("alert_same_type")
     @Expose
     var alertSameType: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehInspectBookshelf.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehInspectBookshelf.kt
@@ -2,37 +2,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehInspectBookshelf {
-
+class BehInspectBookshelf : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("search_count")
     @Expose
     var searchCount: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehInvestigateSuspiciousLocation.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehInvestigateSuspiciousLocation.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehInvestigateSuspiciousLocation {
+class BehInvestigateSuspiciousLocation : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehJumpToBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehJumpToBlock.kt
@@ -2,45 +2,37 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
-import com.lop.devtools.monstera.files.beh.entitiy.components.Components
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehJumpToBlock {
+class BehJumpToBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("search_width")
     @Expose
     var searchWidth: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("minimum_path_length")
     @Expose
     var minimumPathLength: Number? = null
         
-
     @SerializedName("minimum_distance")
     @Expose
     var minimumDistance: Number? = null
         
-
     @SerializedName("scale_factor")
     @Expose
     var scaleFactor: Number? = null
         
-
     @SerializedName("max_velocity")
     @Expose
     var maxVelocity: Number? = null
         
-
     @SerializedName("cooldown_range")
     @Expose
     var cooldownRangeData: MutableList<Number>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehKnockbackRoar.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehKnockbackRoar.kt
@@ -1,47 +1,43 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehKnockbackRoar {
+class BehKnockbackRoar : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("attack_time")
     @Expose
     var attackTime: Number? = null
         
-
     @SerializedName("knockback_damage")
     @Expose
     var knockbackDamage: Number? = null
         
-
     @SerializedName("knockback_horizontal_strength")
     @Expose
     var knockbackHorizontalStrength: Number? = null
         
-
     @SerializedName("knockback_vertical_strength")
     @Expose
     var knockbackVerticalStrength: Number? = null
         
-
     @SerializedName("knockback_range")
     @Expose
     var knockbackRange: Number? = null
         
-
     @SerializedName("knockback_filters")
     @Expose
     var knockbackFiltersData: BehEntityFilter? = null
@@ -88,6 +84,7 @@ class BehKnockbackRoar {
 
     @SerializedName("on_roar_end")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onRoarEndData: OnRoarEnd? = null
         @MonsteraBuildSetter set
 
@@ -110,10 +107,9 @@ class BehKnockbackRoar {
     var cooldownTime: Number? = null
         
 
-    class OnRoarEnd {
+    class OnRoarEnd : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLayDown.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLayDown.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehLayDown {
+class BehLayDown : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
         
-
     @SerializedName("random_stop_interval")
     @Expose
     var randomStopInterval: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLayEgg.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLayEgg.kt
@@ -1,37 +1,35 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehLayEgg {
+class BehLayEgg : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("target_blocks")
     @Expose
     var targetBlocksData: MutableList<String>? = null
@@ -53,29 +51,25 @@ class BehLayEgg {
     @Expose
     var allowLayingFromBelow: Boolean? = null
         
-
     @SerializedName("use_default_animation")
     @Expose
     var useDefaultAnimation: Boolean? = null
         
-
     @SerializedName("lay_seconds")
     @Expose
     var laySeconds: Number? = null
         
-
     @SerializedName("egg_type")
     @Expose
     var eggType: String? = null
         
-
     @SerializedName("lay_egg_sound")
     @Expose
     var layEggSound: String? = null
         
-
     @SerializedName("on_lay")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onLayData: OnLay? = null
         @MonsteraBuildSetter set
 
@@ -94,15 +88,13 @@ class BehLayEgg {
         onLayData = (onLayData ?: OnLay()).apply(value)
     }
 
-    class OnLay {
+    class OnLay : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLeapAtTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLeapAtTarget.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehLeapAtTarget {
+class BehLeapAtTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("target_dist")
     @Expose
     var targetDist: Number? = null
         
-
     @SerializedName("yd")
     @Expose
     var yd: Number? = null
         
-
     @SerializedName("must_be_on_ground")
     @Expose
     var mustBeOnGround: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtEntity.kt
@@ -3,25 +3,23 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehLookAtEntity {
+class BehLookAtEntity : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("look_distance")
     @Expose
     var lookDistance: Number? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null
         
-
     /**
      * com.lop.devtools.monstera.files.beh.entitiy.components.scraped.Filters allow data objects to specify test criteria which allows their use.
      * ```
@@ -42,9 +40,7 @@ class BehLookAtEntity {
     @Expose
     var angleOfViewHorizontal: Number? = null
         
-
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtPlayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtPlayer.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehLookAtPlayer {
+class BehLookAtPlayer : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("target_distance")
     @Expose
     var targetDistance: Number? = null
-        
 
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
-        
 
     @SerializedName("look_distance")
     @Expose
     var lookDistance: Number? = null
-        
 
     @SerializedName("angle_of_view_horizontal")
     @Expose
     var angleOfViewHorizontal: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtTarget.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehLookAtTarget {
+class BehLookAtTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtTradingPlayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehLookAtTradingPlayer.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehLookAtTradingPlayer {
+class BehLookAtTradingPlayer : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMakeLove.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMakeLove.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMakeLove {
-
+class BehMakeLove : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMeleeAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMeleeAttack.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMeleeAttack {
+class BehMeleeAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("track_target")
     @Expose
     var trackTarget: Boolean? = null
         
-
     @SerializedName("reach_multiplier")
     @Expose
     var reachMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMeleeBoxAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMeleeBoxAttack.kt
@@ -1,19 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehMeleeBoxAttack {
+class BehMeleeBoxAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("on_kill")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onKillData: OnKill? = null
         @MonsteraBuildSetter set
 
@@ -35,15 +38,14 @@ class BehMeleeBoxAttack {
     @SerializedName("attack_once")
     @Expose
     var attackOnce: Boolean? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("on_attack")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onAttackData: OnAttack? = null
         @MonsteraBuildSetter set
 
@@ -65,55 +67,45 @@ class BehMeleeBoxAttack {
     @SerializedName("track_target")
     @Expose
     var trackTarget: Boolean? = null
-        
 
     @SerializedName("random_stop_interval")
     @Expose
     var randomStopInterval: Number? = null
-        
 
     @SerializedName("can_spread_on_fire")
     @Expose
     var canSpreadOnFire: Boolean? = null
-        
 
     @SerializedName("require_complete_path")
     @Expose
     var requireCompletePath: Boolean? = null
-        
 
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
-        
 
     @SerializedName("melee_fov")
     @Expose
     var meleeFov: Number? = null
-        
 
-    class OnKill {
+    class OnKill : MonsteraRawFile() {
 
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnAttack {
+    class OnAttack : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMingle.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMingle.kt
@@ -3,35 +3,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMingle {
+class BehMingle : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
         
-
     @SerializedName("mingle_partner_type")
     @Expose
     var minglePartnerType: String? = null
         
-
     @SerializedName("mingle_distance")
     @Expose
     var mingleDistance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMountPathing.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMountPathing.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMountPathing {
+class BehMountPathing : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("target_dist")
     @Expose
     var targetDist: Number? = null
         
-
     @SerializedName("track_target")
     @Expose
     var trackTarget: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveIndoors.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveIndoors.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveIndoors {
+class BehMoveIndoors : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("timeout_cooldown")
     @Expose
     var timeoutCooldown: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveOutdoors.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveOutdoors.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveOutdoors {
+class BehMoveOutdoors : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("timeout_cooldown")
     @Expose
     var timeoutCooldown: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveThroughVillage.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveThroughVillage.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveThroughVillage {
+class BehMoveThroughVillage : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("only_at_night")
     @Expose
     var onlyAtNight: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToBlock.kt
@@ -1,53 +1,48 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehMoveToBlock {
+class BehMoveToBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("tick_interval")
     @Expose
     var tickInterval: Number? = null
         
-
     @SerializedName("start_chance")
     @Expose
     var startChance: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("stay_duration")
     @Expose
     var stayDuration: Number? = null
         
-
     @SerializedName("target_selection_method")
     @Expose
     var targetSelectionMethod: String? = null
         
-
     @SerializedName("target_offset")
     @Expose
     var targetOffsetData: MutableList<Number>? = null
@@ -80,6 +75,7 @@ class BehMoveToBlock {
 
     @SerializedName("target_blocks")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var targetBlocksData: MutableList<String>? = null
 
     fun targetBlocks(vararg value: String) {
@@ -88,6 +84,7 @@ class BehMoveToBlock {
 
     @SerializedName("on_stay_completed")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onStayCompletedData: MutableList<OnStayCompleted>? = null
         @MonsteraBuildSetter set
 
@@ -108,6 +105,7 @@ class BehMoveToBlock {
 
     @SerializedName("on_reach")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onReachData: MutableList<OnReach>? = null
         @MonsteraBuildSetter set
 
@@ -126,27 +124,23 @@ class BehMoveToBlock {
         onReachData = (onReachData ?: mutableListOf()).also { it.add(OnReach().apply(value)) }
     }
 
-    class OnStayCompleted {
+    class OnStayCompleted : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnReach {
+    class OnReach : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToLand.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToLand.kt
@@ -2,32 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveToLand {
-
+class BehMoveToLand : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("search_count")
     @Expose
     var searchCount: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToLiquid.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToLiquid.kt
@@ -2,37 +2,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveToLiquid {
-
+class BehMoveToLiquid : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("material_type")
     @Expose
     var materialType: String? = null
         
-
     @SerializedName("search_count")
     @Expose
     var searchCount: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToRandomBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToRandomBlock.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveToRandomBlock {
+class BehMoveToRandomBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
         
-
     @SerializedName("block_distance")
     @Expose
     var blockDistance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToVillage.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToVillage.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveToVillage {
+class BehMoveToVillage : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToWater.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveToWater.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveToWater {
+class BehMoveToWater : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
-        
 
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
-        
 
     @SerializedName("search_count")
     @Expose
     var searchCount: Number? = null
-        
 
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveTowardsDwellingRestriction.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveTowardsDwellingRestriction.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveTowardsDwellingRestriction {
+class BehMoveTowardsDwellingRestriction : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveTowardsHomeRestriction.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveTowardsHomeRestriction.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveTowardsHomeRestriction {
+class BehMoveTowardsHomeRestriction : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveTowardsTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehMoveTowardsTarget.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehMoveTowardsTarget {
+class BehMoveTowardsTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehNap.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehNap.kt
@@ -3,35 +3,31 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehNap {
+class BehNap : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("cooldown_min")
     @Expose
     var cooldownMin: Number? = null
         
-
     @SerializedName("cooldown_max")
     @Expose
     var cooldownMax: Number? = null
         
-
     @SerializedName("mob_detect_dist")
     @Expose
     var mobDetectDist: Number? = null
         
-
     @SerializedName("mob_detect_height")
     @Expose
     var mobDetectHeight: Number? = null
         
-
     @SerializedName("can_nap_filters")
     @Expose
     var canNapFiltersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehNearestAttackableTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehNearestAttackableTarget.kt
@@ -1,12 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehNearestAttackableTarget {
+class BehNearestAttackableTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
@@ -29,6 +32,7 @@ class BehNearestAttackableTarget {
 
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehNearestPrioritizedAttackableTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehNearestPrioritizedAttackableTarget.kt
@@ -1,34 +1,34 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehNearestPrioritizedAttackableTarget {
+class BehNearestPrioritizedAttackableTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("attack_interval")
     @Expose
     var attackInterval: Number? = null
         
-
     @SerializedName("reselect_targets")
     @Expose
     var reselectTargets: Boolean? = null
         
-
     @SerializedName("target_search_height")
     @Expose
     var targetSearchHeight: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 
@@ -52,19 +52,15 @@ class BehNearestPrioritizedAttackableTarget {
     @Expose
     var withinRadius: Number? = null
         
-
     @SerializedName("persist_time")
     @Expose
     var persistTime: Number? = null
         
-
     @SerializedName("must_see")
     @Expose
     var mustSee: Boolean? = null
         
-
     @SerializedName("must_reach")
     @Expose
     var mustReach: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOcelotSitOnBlock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOcelotSitOnBlock.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehOcelotSitOnBlock {
+class BehOcelotSitOnBlock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
-
+    
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOcelotattack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOcelotattack.kt
@@ -2,61 +2,50 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehOcelotattack {
+class BehOcelotattack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
         
-
     @SerializedName("x_max_rotation")
     @Expose
     var xMaxRotation: Number? = null
         
-
     @SerializedName("y_max_head_rotation")
     @Expose
     var yMaxHeadRotation: Number? = null
         
-
     @SerializedName("max_distance")
     @Expose
     var maxDistance: Number? = null
         
-
     @SerializedName("max_sneak_range")
     @Expose
     var maxSneakRange: Number? = null
         
-
     @SerializedName("max_sprint_range")
     @Expose
     var maxSprintRange: Number? = null
         
-
     @SerializedName("reach_multiplier")
     @Expose
     var reachMultiplier: Number? = null
         
-
     @SerializedName("sneak_speed_multiplier")
     @Expose
     var sneakSpeedMultiplier: Number? = null
         
-
     @SerializedName("sprint_speed_multiplier")
     @Expose
     var sprintSpeedMultiplier: Number? = null
         
-
     @SerializedName("walk_speed_multiplier")
     @Expose
     var walkSpeedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOfferFlower.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOfferFlower.kt
@@ -3,15 +3,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehOfferFlower {
+class BehOfferFlower : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOpenDoor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOpenDoor.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehOpenDoor {
+class BehOpenDoor : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOwnerHurtByTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOwnerHurtByTarget.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehOwnerHurtByTarget {
+class BehOwnerHurtByTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOwnerHurtTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehOwnerHurtTarget.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehOwnerHurtTarget {
+class BehOwnerHurtTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPanic.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPanic.kt
@@ -1,38 +1,37 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehPanic {
+class BehPanic : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("force")
     @Expose
     var force: Boolean? = null
-        
 
     @SerializedName("ignore_mob_damage")
     @Expose
     var ignoreMobDamage: Boolean? = null
-        
 
     @SerializedName("panic_sound")
     @Expose
     var panicSound: String? = null
-        
 
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -55,16 +54,13 @@ class BehPanic {
     @Expose
     var preferWater: Boolean? = null
         
-
-    class SoundInterval {
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
-            
-
+        
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPetSleepWithOwner.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPetSleepWithOwner.kt
@@ -3,30 +3,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehPetSleepWithOwner {
+class BehPetSleepWithOwner : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_radius")
     @Expose
     var searchRadius: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPickupItems.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPickupItems.kt
@@ -2,53 +2,44 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehPickupItems {
+class BehPickupItems : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("max_dist")
     @Expose
     var maxDist: Number? = null
-        
 
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
-        
 
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("pickup_based_on_chance")
     @Expose
     var pickupBasedOnChance: Boolean? = null
-        
 
     @SerializedName("can_pickup_any_item")
     @Expose
     var canPickupAnyItem: Boolean? = null
-        
 
     @SerializedName("can_pickup_to_hand_or_equipment")
     @Expose
     var canPickupToHandOrEquipment: Boolean? = null
-        
 
     @SerializedName("pickup_same_items_as_in_hand")
     @Expose
     var pickupSameItemsAsInHand: Boolean? = null
-        
 
     @SerializedName("excluded_items")
     @Expose
@@ -61,5 +52,4 @@ class BehPickupItems {
     @SerializedName("cooldown_after_being_attacked")
     @Expose
     var cooldownAfterBeingAttacked: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPlay.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPlay.kt
@@ -1,24 +1,26 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehPlay {
+class BehPlay : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("friend_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var friendTypesData: MutableList<FriendTypes>? = null
         @MonsteraBuildSetter set
 
@@ -35,7 +37,7 @@ class BehPlay {
         friendTypesData = (friendTypesData ?: mutableListOf()).also { it.add(FriendTypes().apply(value)) }
     }
 
-    class FriendTypes {
+    class FriendTypes : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPlayDead.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPlayDead.kt
@@ -3,43 +3,37 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehPlayDead {
+class BehPlayDead : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
-        
 
     @SerializedName("force_below_health")
     @Expose
     var forceBelowHealth: Number? = null
-        
 
     @SerializedName("random_start_chance")
     @Expose
     var randomStartChance: Number? = null
-        
 
     @SerializedName("random_damage_range")
     @Expose
     var randomDamageRangeData: MutableList<Number>? = null
-        
 
     fun randomDamageRange(vararg value: Number) {
         randomDamageRangeData = (randomDamageRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
-
     @SerializedName("damage_sources")
     @Expose
     var damageSourcesData: MutableList<String>? = null
-        
 
     fun damageSources(vararg value: String) {
         damageSourcesData = (damageSourcesData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -48,7 +42,6 @@ class BehPlayDead {
     @SerializedName("apply_regeneration")
     @Expose
     var applyRegeneration: Boolean? = null
-        
 
     @SerializedName("filters")
     @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPlayerRideTamed.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehPlayerRideTamed.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class BehPlayerRideTamed
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class BehPlayerRideTamed : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRaidGarden.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRaidGarden.kt
@@ -2,19 +2,17 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRaidGarden {
+class BehRaidGarden : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("blocks")
     @Expose
     var blocksData: MutableList<String>? = null
         
-
     fun blocks(vararg value: String) {
         blocksData = (blocksData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
@@ -23,29 +21,23 @@ class BehRaidGarden {
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("max_to_eat")
     @Expose
     var maxToEat: Number? = null
         
-
     @SerializedName("initial_eat_delay")
     @Expose
     var initialEatDelay: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRamAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRamAttack.kt
@@ -1,62 +1,55 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehRamAttack {
+class BehRamAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("run_speed")
     @Expose
     var runSpeed: Number? = null
         
-
     @SerializedName("ram_speed")
     @Expose
     var ramSpeed: Number? = null
         
-
     @SerializedName("min_ram_distance")
     @Expose
     var minRamDistance: Number? = null
         
-
     @SerializedName("ram_distance")
     @Expose
     var ramDistance: Number? = null
         
-
     @SerializedName("knockback_force")
     @Expose
     var knockbackForce: Number? = null
-        
 
     @SerializedName("knockback_height")
     @Expose
     var knockbackHeight: Number? = null
         
-
     @SerializedName("pre_ram_sound")
     @Expose
     var preRamSound: String? = null
         
-
     @SerializedName("ram_impact_sound")
     @Expose
     var ramImpactSound: String? = null
         
-
     @SerializedName("cooldown_range")
     @Expose
     var cooldownRangeData: MutableList<Number>? = null
         
-
     @Components.VanillaComponentMarker
     fun cooldownRange(vararg value: Number) {
         cooldownRangeData = (cooldownRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -64,10 +57,10 @@ class BehRamAttack {
 
     @SerializedName("on_start")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onStartData: MutableList<OnStart>? = null
         @MonsteraBuildSetter set
         
-
     /**
      *
      * ```
@@ -83,7 +76,7 @@ class BehRamAttack {
         onStartData = (onStartData ?: mutableListOf()).also { it.add(OnStart().apply(value)) }
     }
 
-    class OnStart {
+    class OnStart : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomBreach.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomBreach.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomBreach {
+class BehRandomBreach : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
         
-
     @SerializedName("xz_dist")
     @Expose
     var xzDist: Number? = null
         
-
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomFly.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomFly.kt
@@ -2,41 +2,34 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomFly {
+class BehRandomFly : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("xz_dist")
     @Expose
     var xzDist: Number? = null
         
-
     @SerializedName("y_dist")
     @Expose
     var yDist: Number? = null
         
-
     @SerializedName("y_offset")
     @Expose
     var yOffset: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("can_land_on_trees")
     @Expose
     var canLandOnTrees: Boolean? = null
         
-
     @SerializedName("avoid_damage_blocks")
     @Expose
     var avoidDamageBlocks: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomHover.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomHover.kt
@@ -2,38 +2,32 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomHover {
+class BehRandomHover : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("xz_dist")
     @Expose
     var xzDist: Number? = null
-        
 
     @SerializedName("y_dist")
     @Expose
     var yDist: Number? = null
-        
 
     @SerializedName("y_offset")
     @Expose
     var yOffset: Number? = null
-        
 
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
-        
 
     @SerializedName("hover_height")
     @Expose
     var hoverHeightData: MutableList<Number>? = null
-        
 
     fun hoverHeight(vararg value: Number) {
         hoverHeightData = (hoverHeightData ?: mutableListOf()).also { it.addAll(value.toList()) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomLookAround.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomLookAround.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomLookAround {
+class BehRandomLookAround : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("look_distance")
     @Expose
     var lookDistance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomLookAroundAndSit.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomLookAroundAndSit.kt
@@ -2,61 +2,50 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomLookAroundAndSit {
+class BehRandomLookAroundAndSit : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("continue_if_leashed")
     @Expose
     var continueIfLeashed: Boolean? = null
         
-
     @SerializedName("continue_sitting_on_reload")
     @Expose
     var continueSittingOnReload: Boolean? = null
         
-
     @SerializedName("min_look_count")
     @Expose
     var minLookCount: Number? = null
         
-
     @SerializedName("max_look_count")
     @Expose
     var maxLookCount: Number? = null
         
-
     @SerializedName("min_look_time")
     @Expose
     var minLookTime: Number? = null
         
-
     @SerializedName("max_look_time")
     @Expose
     var maxLookTime: Number? = null
         
-
     @SerializedName("min_angle_of_view_horizontal")
     @Expose
     var minAngleOfViewHorizontal: Number? = null
         
-
     @SerializedName("max_angle_of_view_horizontal")
     @Expose
     var maxAngleOfViewHorizontal: Number? = null
         
-
     @SerializedName("random_look_around_cooldown")
     @Expose
     var randomLookAroundCooldown: Number? = null
         
-
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomSearchAndDig.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomSearchAndDig.kt
@@ -1,31 +1,32 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
+import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables
+import com.lop.devtools.monstera.getMonsteraLogger
 
-class BehRandomSearchAndDig {
+class BehRandomSearchAndDig : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("find_valid_position_retries")
     @Expose
     var findValidPositionRetries: Number? = null
-        
 
     @SerializedName("target_blocks")
     @Expose
     var targetBlocksData: MutableList<String>? = null
-        
 
     fun targetBlocks(vararg value: String) {
         targetBlocksData = (targetBlocksData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -34,27 +35,22 @@ class BehRandomSearchAndDig {
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
-        
 
     @SerializedName("search_range_xz")
     @Expose
     var searchRangeXz: Number? = null
-        
 
     @SerializedName("search_range_y")
     @Expose
     var searchRangeY: Number? = null
-        
 
     @SerializedName("cooldown_range")
     @Expose
     var cooldownRange: Number? = null
-        
 
     @SerializedName("digging_duration_range")
     @Expose
     var diggingDurationRangeData: MutableList<Number>? = null
-        
 
     fun diggingDurationRange(vararg value: Number) {
         diggingDurationRangeData = (diggingDurationRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -63,20 +59,35 @@ class BehRandomSearchAndDig {
     @SerializedName("item_table")
     @Expose
     var itemTable: String? = null
-        
+
+    /**
+     * ```
+     * table("name") {
+     *     pool {  }
+     * }
+     * ```
+     */
+    fun itemTable(tableName: String, data: BehLootTables.() -> Unit) {
+        val lootTables = BehLootTables().apply(data)
+        val target = BehLootTables.Entity(lootTables).build(tableName)
+        target.fold({
+            itemTable = BehLootTables.resolveRelative(it)
+        }, {
+            getMonsteraLogger(this::class.simpleName ?: "Entity search and dig").warn("Item table not added!")
+        })
+    }
 
     @SerializedName("spawn_item_after_seconds")
     @Expose
     var spawnItemAfterSeconds: Number? = null
-        
 
     @SerializedName("spawn_item_pos_offset")
     @Expose
     var spawnItemPosOffset: Number? = null
-        
 
     @SerializedName("on_searching_start")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onSearchingStartData: OnSearchingStart? = null
         @MonsteraBuildSetter set
 
@@ -97,6 +108,7 @@ class BehRandomSearchAndDig {
 
     @SerializedName("on_fail_during_searching")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onFailDuringSearchingData: OnFailDuringSearching? = null
         @MonsteraBuildSetter set
 
@@ -117,6 +129,7 @@ class BehRandomSearchAndDig {
 
     @SerializedName("on_digging_start")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onDiggingStartData: OnDiggingStart? = null
         @MonsteraBuildSetter set
 
@@ -137,6 +150,7 @@ class BehRandomSearchAndDig {
 
     @SerializedName("on_item_found")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onItemFoundData: OnItemFound? = null
         @MonsteraBuildSetter set
 
@@ -157,6 +171,7 @@ class BehRandomSearchAndDig {
 
     @SerializedName("on_fail_during_digging")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onFailDuringDiggingData: OnFailDuringDigging? = null
         @MonsteraBuildSetter set
 
@@ -177,6 +192,7 @@ class BehRandomSearchAndDig {
 
     @SerializedName("on_success")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onSuccessData: OnSuccess? = null
         @MonsteraBuildSetter set
 
@@ -195,75 +211,63 @@ class BehRandomSearchAndDig {
         onSuccessData = (onSuccessData ?: OnSuccess()).apply(value)
     }
 
-    class OnSearchingStart {
+    class OnSearchingStart : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnFailDuringSearching {
+    class OnFailDuringSearching : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: String? = null
-            
     }
 
-    class OnDiggingStart {
+    class OnDiggingStart : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnItemFound {
+    class OnItemFound : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnFailDuringDigging {
+    class OnFailDuringDigging : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnSuccess {
+    class OnSuccess : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomSitting.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomSitting.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomSitting {
+class BehRandomSitting : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("start_chance")
     @Expose
     var startChance: Number? = null
         
-
     @SerializedName("stop_chance")
     @Expose
     var stopChance: Number? = null
         
-
     @SerializedName("cooldown")
     @Expose
     var cooldown: Number? = null
         
-
     @SerializedName("min_sit_time")
     @Expose
     var minSitTime: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomStroll.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomStroll.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomStroll {
+class BehRandomStroll : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("xz_dist")
     @Expose
     var xzDist: Number? = null
-        
 
     @SerializedName("y_dist")
     @Expose
     var yDist: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomSwim.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRandomSwim.kt
@@ -2,36 +2,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRandomSwim {
+class BehRandomSwim : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
         
-
     @SerializedName("xz_dist")
     @Expose
     var xzDist: Number? = null
         
-
     @SerializedName("y_dist")
     @Expose
     var yDist: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("avoid_surface")
     @Expose
     var avoidSurface: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRangedAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRangedAttack.kt
@@ -3,10 +3,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.DebugMarker
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class BehRangedAttack {
+class BehRangedAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehReceiveLove.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehReceiveLove.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehReceiveLove {
+class BehReceiveLove : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRestrictOpenDoor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRestrictOpenDoor.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRestrictOpenDoor {
+class BehRestrictOpenDoor : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRiseToLiquidLevel.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRiseToLiquidLevel.kt
@@ -2,26 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRiseToLiquidLevel {
+class BehRiseToLiquidLevel : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("liquid_y_offset")
     @Expose
     var liquidYOffset: Number? = null
         
-
     @SerializedName("rise_delta")
     @Expose
     var riseDelta: Number? = null
         
-
     @SerializedName("sink_delta")
     @Expose
     var sinkDelta: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRoar.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRoar.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRoar {
+class BehRoar : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRoll.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRoll.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRoll {
+class BehRoll : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRunAroundLikeCrazy.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehRunAroundLikeCrazy.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehRunAroundLikeCrazy {
+class BehRunAroundLikeCrazy : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehScared.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehScared.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehScared {
+class BehScared : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("sound_interval")
     @Expose
     var soundInterval: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSendEvent.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSendEvent.kt
@@ -1,12 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehSendEvent {
+class BehSendEvent : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
@@ -14,6 +17,7 @@ class BehSendEvent {
 
     @SerializedName("event_choices")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var eventChoicesData: MutableList<EventChoices>? = null
         @MonsteraBuildSetter set
 
@@ -37,38 +41,31 @@ class BehSendEvent {
         eventChoicesData = (eventChoicesData ?: mutableListOf()).also { it.add(EventChoices().apply(value)) }
     }
 
-    class EventChoices {
-
+    class EventChoices : MonsteraRawFile() {
         @SerializedName("min_activation_range")
         @Expose
         var minActivationRange: Number? = null
             
-
         @SerializedName("max_activation_range")
         @Expose
         var maxActivationRange: Number? = null
             
-
         @SerializedName("cooldown_time")
         @Expose
         var cooldownTime: Number? = null
             
-
         @SerializedName("cast_duration")
         @Expose
         var castDuration: Number? = null
             
-
         @SerializedName("particle_color")
         @Expose
         var particleColor: String? = null
             
-
         @SerializedName("weight")
         @Expose
         var weight: Number? = null
             
-
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null
@@ -91,9 +88,9 @@ class BehSendEvent {
         @Expose
         var startSoundEvent: String? = null
             
-
         @SerializedName("sequence")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var sequenceData: MutableList<Sequence>? = null
             @MonsteraBuildSetter set
 
@@ -114,20 +111,17 @@ class BehSendEvent {
         }
     }
 
-    class Sequence {
+    class Sequence : MonsteraRawFile() {
         @SerializedName("base_delay")
         @Expose
         var baseDelay: Number? = null
             
-
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("sound_event")
         @Expose
         var soundEvent: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehShareItems.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehShareItems.kt
@@ -1,34 +1,34 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehShareItems {
+class BehShareItems : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("max_dist")
     @Expose
     var maxDist: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSilverfishMergeWithStone.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSilverfishMergeWithStone.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSilverfishMergeWithStone {
+class BehSilverfishMergeWithStone : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSilverfishWakeUpFriends.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSilverfishWakeUpFriends.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSilverfishWakeUpFriends {
-
+class BehSilverfishWakeUpFriends : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSkeletonHorseTrap.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSkeletonHorseTrap.kt
@@ -2,22 +2,19 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSkeletonHorseTrap {
+class BehSkeletonHorseTrap : MonsteraRawFile() {
 
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSleep.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSleep.kt
@@ -2,41 +2,34 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSleep {
+class BehSleep : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("sleep_collider_height")
     @Expose
     var sleepColliderHeight: Number? = null
         
-
     @SerializedName("sleep_collider_width")
     @Expose
     var sleepColliderWidth: Number? = null
         
-
     @SerializedName("sleep_y_offset")
     @Expose
     var sleepYOffset: Number? = null
         
-
     @SerializedName("timeout_cooldown")
     @Expose
     var timeoutCooldown: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeAttack.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSlimeAttack {
-
+class BehSlimeAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeFloat.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeFloat.kt
@@ -2,22 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSlimeFloat {
-
+class BehSlimeFloat : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("jump_chance_percentage")
     @Expose
     var jumpChancePercentage: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeKeepOnJumping.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeKeepOnJumping.kt
@@ -2,17 +2,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSlimeKeepOnJumping {
+class BehSlimeKeepOnJumping : MonsteraRawFile() {
 
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeRandomDirection.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSlimeRandomDirection.kt
@@ -2,27 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSlimeRandomDirection {
-
+class BehSlimeRandomDirection : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("add_random_time_range")
     @Expose
     var addRandomTimeRange: Number? = null
         
-
     @SerializedName("turn_range")
     @Expose
     var turnRange: Number? = null
         
-
     @SerializedName("min_change_direction_time")
     @Expose
     var minChangeDirectionTime: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSnacking.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSnacking.kt
@@ -2,34 +2,29 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSnacking {
+class BehSnacking : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("snacking_cooldown")
     @Expose
     var snackingCooldown: Number? = null
         
-
     @SerializedName("snacking_cooldown_min")
     @Expose
     var snackingCooldownMin: Number? = null
         
-
     @SerializedName("snacking_stop_chance")
     @Expose
     var snackingStopChance: Number? = null
         
-
     @SerializedName("items")
     @Expose
     var itemsData: MutableList<String>? = null
         
-
     fun items(vararg value: String) {
         itemsData = (itemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSneeze.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSneeze.kt
@@ -1,34 +1,36 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
+import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables
+import com.lop.devtools.monstera.getMonsteraLogger
 
-class BehSneeze {
+class BehSneeze : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
-        
 
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
-        
 
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
-        
 
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 
@@ -49,25 +51,38 @@ class BehSneeze {
     @SerializedName("drop_item_chance")
     @Expose
     var dropItemChance: Number? = null
-        
 
     @SerializedName("loot_table")
     @Expose
     var lootTable: String? = null
-        
+
+    /**
+     * ```
+     * table("name") {
+     *     pool {  }
+     * }
+     * ```
+     */
+    fun lootTable(tableName: String, data: BehLootTables.() -> Unit) {
+        val lootTables = BehLootTables().apply(data)
+        val target = BehLootTables.Entity(lootTables).build(tableName)
+        target.fold({
+            lootTable = BehLootTables.resolveRelative(it)
+        }, {
+            getMonsteraLogger(this::class.simpleName ?: "Entity Sneeze").warn("Equipment table not added!")
+        })
+    }
 
     @SerializedName("prepare_sound")
     @Expose
     var prepareSound: String? = null
-        
 
     @SerializedName("prepare_time")
     @Expose
     var prepareTime: Number? = null
-        
 
     @SerializedName("sound")
     @Expose
     var sound: String? = null
-        
+
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSniff.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSniff.kt
@@ -2,38 +2,32 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSniff {
+class BehSniff : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
-        
 
     @SerializedName("sniffing_radius")
     @Expose
     var sniffingRadius: Number? = null
-        
 
     @SerializedName("suspicion_radius_horizontal")
     @Expose
     var suspicionRadiusHorizontal: Number? = null
-        
 
     @SerializedName("suspicion_radius_vertical")
     @Expose
     var suspicionRadiusVertical: Number? = null
-        
 
     @SerializedName("cooldown_range")
     @Expose
     var cooldownRangeData: MutableList<Number>? = null
-        
 
     fun cooldownRange(vararg value: Number) {
         cooldownRangeData = (cooldownRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSonicBoom.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSonicBoom.kt
@@ -2,72 +2,58 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSonicBoom {
-
+class BehSonicBoom : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("attack_damage")
     @Expose
     var attackDamage: Number? = null
         
-
     @SerializedName("attack_range_horizontal")
     @Expose
     var attackRangeHorizontal: Number? = null
         
-
     @SerializedName("attack_range_vertical")
     @Expose
     var attackRangeVertical: Number? = null
         
-
     @SerializedName("attack_cooldown")
     @Expose
     var attackCooldown: Number? = null
         
-
     @SerializedName("knockback_vertical_strength")
     @Expose
     var knockbackVerticalStrength: Number? = null
         
-
     @SerializedName("knockback_horizontal_strength")
     @Expose
     var knockbackHorizontalStrength: Number? = null
         
-
     @SerializedName("knockback_height_cap")
     @Expose
     var knockbackHeightCap: Number? = null
         
-
     @SerializedName("duration_until_attack_sound")
     @Expose
     var durationUntilAttackSound: Number? = null
         
-
     @SerializedName("charge_sound")
     @Expose
     var chargeSound: String? = null
         
-
     @SerializedName("attack_sound")
     @Expose
     var attackSound: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidDive.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidDive.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSquidDive {
-
+class BehSquidDive : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidFlee.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidFlee.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSquidFlee {
-
+class BehSquidFlee : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidIdle.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidIdle.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSquidIdle {
-
+class BehSquidIdle : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidMoveAwayFromGround.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidMoveAwayFromGround.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSquidMoveAwayFromGround {
+class BehSquidMoveAwayFromGround : MonsteraRawFile() {
 
     @SerializedName("priority")
     @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidOutOfWater.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSquidOutOfWater.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSquidOutOfWater {
-
+class BehSquidOutOfWater : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStalkAndPounceOnTarget.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStalkAndPounceOnTarget.kt
@@ -3,55 +3,47 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehStalkAndPounceOnTarget {
+class BehStalkAndPounceOnTarget : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("stalk_speed")
     @Expose
     var stalkSpeed: Number? = null
         
-
     @SerializedName("max_stalk_dist")
     @Expose
     var maxStalkDist: Number? = null
         
-
     @SerializedName("leap_height")
     @Expose
     var leapHeight: Number? = null
         
-
     @SerializedName("leap_dist")
     @Expose
     var leapDist: Number? = null
         
-
     @SerializedName("pounce_max_dist")
     @Expose
     var pounceMaxDist: Number? = null
         
-
     @SerializedName("interest_time")
     @Expose
     var interestTime: Number? = null
         
-
     @SerializedName("stuck_time")
     @Expose
     var stuckTime: Number? = null
         
-
     @SerializedName("strike_dist")
     @Expose
     var strikeDist: Number? = null
         
-
     @SerializedName("stuck_blocks")
     @Expose
     var stuckBlocksData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStayNearNoteblock.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStayNearNoteblock.kt
@@ -2,27 +2,22 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehStayNearNoteblock {
-
+class BehStayNearNoteblock : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed")
     @Expose
     var speed: Number? = null
-        
 
     @SerializedName("start_distance")
     @Expose
     var startDistance: Number? = null
-        
 
     @SerializedName("stop_distance")
     @Expose
     var stopDistance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStayWhileSitting.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStayWhileSitting.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehStayWhileSitting {
-
+class BehStayWhileSitting : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStompAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStompAttack.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehStompAttack {
+class BehStompAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("track_target")
     @Expose
     var trackTarget: Boolean? = null
         
-
     @SerializedName("require_complete_path")
     @Expose
     var requireCompletePath: Boolean? = null
         
-
     @SerializedName("stomp_range_multiplier")
     @Expose
     var stompRangeMultiplier: Number? = null
         
-
     @SerializedName("no_damage_range_multiplier")
     @Expose
     var noDamageRangeMultiplier: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStompTurtleEgg.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStompTurtleEgg.kt
@@ -2,36 +2,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehStompTurtleEgg {
+class BehStompTurtleEgg : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("search_height")
     @Expose
     var searchHeight: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStrollTowardsVillage.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehStrollTowardsVillage.kt
@@ -3,35 +3,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehStrollTowardsVillage {
+class BehStrollTowardsVillage : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("goal_radius")
     @Expose
     var goalRadius: Number? = null
         
-
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("start_chance")
     @Expose
     var startChance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSummonEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSummonEntity.kt
@@ -1,19 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehSummonEntity {
+class BehSummonEntity : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("summon_choices")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var summonChoicesData: MutableList<SummonChoices>? = null
         @MonsteraBuildSetter set
 
@@ -37,45 +40,38 @@ class BehSummonEntity {
         summonChoicesData = (summonChoicesData ?: mutableListOf()).also { it.add(SummonChoices().apply(value)) }
     }
 
-    class SummonChoices {
-
+    class SummonChoices : MonsteraRawFile() {
         @SerializedName("min_activation_range")
         @Expose
         var minActivationRange: Number? = null
             
-
         @SerializedName("max_activation_range")
         @Expose
         var maxActivationRange: Number? = null
             
-
         @SerializedName("cooldown_time")
         @Expose
         var cooldownTime: Number? = null
             
-
         @SerializedName("weight")
         @Expose
         var weight: Number? = null
             
-
         @SerializedName("cast_duration")
         @Expose
         var castDuration: Number? = null
             
-
         @SerializedName("particle_color")
         @Expose
         var particleColor: String? = null
             
-
         @SerializedName("start_sound_event")
         @Expose
         var startSoundEvent: String? = null
             
-
         @SerializedName("sequence")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var sequenceData: MutableList<Sequence>? = null
             @MonsteraBuildSetter set
 
@@ -102,50 +98,41 @@ class BehSummonEntity {
         }
     }
 
-    class Sequence {
+    class Sequence : MonsteraRawFile() {
         @SerializedName("shape")
         @Expose
         var shape: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
             
-
         @SerializedName("base_delay")
         @Expose
         var baseDelay: Number? = null
             
-
         @SerializedName("delay_per_summon")
         @Expose
         var delayPerSummon: Number? = null
             
-
         @SerializedName("num_entities_spawned")
         @Expose
         var numEntitiesSpawned: Number? = null
             
-
         @SerializedName("entity_type")
         @Expose
         var entityType: String? = null
             
-
         @SerializedName("size")
         @Expose
         var size: Number? = null
             
-
         @SerializedName("entity_lifespan")
         @Expose
         var entityLifespan: Number? = null
             
-
         @SerializedName("sound_event")
         @Expose
         var soundEvent: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwell.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwell.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSwell {
+class BehSwell : MonsteraRawFile() {
     @SerializedName("start_distance")
     @Expose
     var startDistance: Number? = null
         
-
     @SerializedName("stop_distance")
     @Expose
     var stopDistance: Number? = null
         
-
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwimIdle.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwimIdle.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSwimIdle {
+class BehSwimIdle : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("idle_time")
     @Expose
     var idleTime: Number? = null
-        
 
     @SerializedName("success_rate")
     @Expose
     var successRate: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwimWander.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwimWander.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSwimWander {
+class BehSwimWander : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("interval")
     @Expose
     var interval: Number? = null
         
-
     @SerializedName("look_ahead")
     @Expose
     var lookAhead: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("wander_time")
     @Expose
     var wanderTime: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwimWithEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwimWithEntity.kt
@@ -1,64 +1,58 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehSwimWithEntity {
+class BehSwimWithEntity : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("success_rate")
     @Expose
     var successRate: Number? = null
         
-
     @SerializedName("chance_to_stop")
     @Expose
     var chanceToStop: Number? = null
         
-
     @SerializedName("state_check_interval")
     @Expose
     var stateCheckInterval: Number? = null
         
-
     @SerializedName("catch_up_threshold")
     @Expose
     var catchUpThreshold: Number? = null
         
-
     @SerializedName("match_direction_threshold")
     @Expose
     var matchDirectionThreshold: Number? = null
         
-
     @SerializedName("catch_up_multiplier")
     @Expose
     var catchUpMultiplier: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("search_range")
     @Expose
     var searchRange: Number? = null
         
-
     @SerializedName("stop_distance")
     @Expose
     var stopDistance: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwoopAttack.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehSwoopAttack.kt
@@ -2,29 +2,25 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehSwoopAttack {
+class BehSwoopAttack : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("damage_reach")
     @Expose
     var damageReach: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("delay_range")
     @Expose
     var delayRangeData: MutableList<Number>? = null
         
-
     fun delayRange(vararg value: Number) {
         delayRangeData = (delayRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTakeFlower.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTakeFlower.kt
@@ -3,15 +3,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehTakeFlower {
+class BehTakeFlower : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTargetWhenPushed.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTargetWhenPushed.kt
@@ -1,24 +1,26 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.BehEntityTypes
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class BehTargetWhenPushed {
+class BehTargetWhenPushed : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("percent_chance")
     @Expose
     var percentChance: Number? = null
         
-
     @SerializedName("entity_types")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var entityTypesData: MutableList<BehEntityTypes>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTempt.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTempt.kt
@@ -2,28 +2,24 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehTempt {
+class BehTempt : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
-        
 
     @SerializedName("can_tempt_vertically")
     @Expose
     var canTemptVertically: Boolean? = null
-        
 
     @SerializedName("items")
     @Expose
     var itemsData: MutableList<String>? = null
-        
 
     fun items(vararg value: String) {
         itemsData = (itemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -32,17 +28,14 @@ class BehTempt {
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
-        
 
     @SerializedName("can_get_scared")
     @Expose
     var canGetScared: Boolean? = null
-        
 
     @SerializedName("tempt_sound")
     @Expose
     var temptSound: String? = null
-        
 
     @SerializedName("sound_interval")
     @Expose
@@ -55,5 +48,4 @@ class BehTempt {
     @SerializedName("can_tempt_while_ridden")
     @Expose
     var canTemptWhileRidden: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTimerFlag_1.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTimerFlag_1.kt
@@ -1,23 +1,23 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehTimerFlag_1 {
-
+class BehTimerFlag_1 : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("control_flags")
     @Expose
     var controlFlagsData: MutableList<String>? = null
         
-
     fun controlFlags(vararg value: String) {
         controlFlagsData = (controlFlagsData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
@@ -26,7 +26,6 @@ class BehTimerFlag_1 {
     @Expose
     var cooldownRangeData: MutableList<Number>? = null
         
-
     fun cooldownRange(vararg value: Number) {
         cooldownRangeData = (cooldownRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
@@ -35,9 +34,9 @@ class BehTimerFlag_1 {
     @Expose
     var durationRange: Number? = null
         
-
     @SerializedName("on_end")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onEndData: OnEnd? = null
         @MonsteraBuildSetter set
 
@@ -56,15 +55,13 @@ class BehTimerFlag_1 {
         onEndData = (onEndData ?: OnEnd()).apply(value)
     }
 
-    class OnEnd {
+    class OnEnd : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTimerFlag_2.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTimerFlag_2.kt
@@ -1,22 +1,23 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehTimerFlag_2 {
+class BehTimerFlag_2 : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("control_flags")
     @Expose
     var controlFlagsData: MutableList<String>? = null
         
-
     fun controlFlags(vararg value: String) {
         controlFlagsData = (controlFlagsData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
@@ -25,7 +26,6 @@ class BehTimerFlag_2 {
     @Expose
     var cooldownRange: Number? = null
         
-
     @SerializedName("duration_range")
     @Expose
     var durationRangeData: MutableList<Number>? = null
@@ -37,6 +37,7 @@ class BehTimerFlag_2 {
 
     @SerializedName("on_end")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onEndData: OnEnd? = null
         @MonsteraBuildSetter set
 
@@ -55,12 +56,11 @@ class BehTimerFlag_2 {
         onEndData = (onEndData ?: OnEnd()).apply(value)
     }
 
-    class OnEnd {
+    class OnEnd : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTimerFlag_3.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTimerFlag_3.kt
@@ -1,33 +1,34 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehTimerFlag_3 {
+class BehTimerFlag_3 : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("cooldown_range")
     @Expose
     var cooldownRange: Number? = null
         
-
     @SerializedName("duration_range")
     @Expose
     var durationRangeData: MutableList<Number>? = null
         
-
     fun durationRange(vararg value: Number) {
         durationRangeData = (durationRangeData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
 
     @SerializedName("on_end")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onEndData: OnEnd? = null
         @MonsteraBuildSetter set
 
@@ -46,15 +47,13 @@ class BehTimerFlag_3 {
         onEndData = (onEndData ?: OnEnd()).apply(value)
     }
 
-    class OnEnd {
+    class OnEnd : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTradeInterest.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTradeInterest.kt
@@ -2,36 +2,30 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehTradeInterest {
+class BehTradeInterest : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("within_radius")
     @Expose
     var withinRadius: Number? = null
         
-
     @SerializedName("interest_time")
     @Expose
     var interestTime: Number? = null
         
-
     @SerializedName("remove_item_time")
     @Expose
     var removeItemTime: Number? = null
         
-
     @SerializedName("carried_item_switch_time")
     @Expose
     var carriedItemSwitchTime: Number? = null
         
-
     @SerializedName("cooldown")
     @Expose
     var cooldown: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTradeWithPlayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehTradeWithPlayer.kt
@@ -3,10 +3,11 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class BehTradeWithPlayer {
+class BehTradeWithPlayer : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWitherRandomAttackPosGoal.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWitherRandomAttackPosGoal.kt
@@ -3,11 +3,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehWitherRandomAttackPosGoal {
-
+class BehWitherRandomAttackPosGoal : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWitherTargetHighestDamage.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWitherTargetHighestDamage.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehWitherTargetHighestDamage {
-
+class BehWitherTargetHighestDamage : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWork.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWork.kt
@@ -1,54 +1,50 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehWork {
+class BehWork : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("active_time")
     @Expose
     var activeTime: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("goal_cooldown")
     @Expose
     var goalCooldown: Number? = null
         
-
     @SerializedName("sound_delay_min")
     @Expose
     var soundDelayMin: Number? = null
         
-
     @SerializedName("sound_delay_max")
     @Expose
     var soundDelayMax: Number? = null
         
-
     @SerializedName("can_work_in_rain")
     @Expose
     var canWorkInRain: Boolean? = null
         
-
     @SerializedName("work_in_rain_tolerance")
     @Expose
     var workInRainTolerance: Number? = null
         
-
     @SerializedName("on_arrival")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onArrivalData: OnArrival? = null
         @MonsteraBuildSetter set
 
@@ -67,16 +63,13 @@ class BehWork {
         onArrivalData = (onArrivalData ?: OnArrival()).apply(value)
     }
 
-    class OnArrival {
-
+    class OnArrival : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWorkComposter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BehWorkComposter.kt
@@ -1,44 +1,42 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BehWorkComposter {
+class BehWorkComposter : MonsteraRawFile() {
     @SerializedName("priority")
     @Expose
     var priority: Number? = null
         
-
     @SerializedName("active_time")
     @Expose
     var activeTime: Number? = null
         
-
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("goal_cooldown")
     @Expose
     var goalCooldown: Number? = null
-        
 
     @SerializedName("can_work_in_rain")
     @Expose
     var canWorkInRain: Boolean? = null
         
-
     @SerializedName("work_in_rain_tolerance")
     @Expose
     var workInRainTolerance: Number? = null
         
-
     @SerializedName("on_arrival")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onArrivalData: OnArrival? = null
         @MonsteraBuildSetter set
 
@@ -57,15 +55,13 @@ class BehWorkComposter {
         onArrivalData = (onArrivalData ?: OnArrival()).apply(value)
     }
 
-    class OnArrival {
+    class OnArrival : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BlockClimber.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BlockClimber.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class BlockClimber
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class BlockClimber : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BlockSensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BlockSensor.kt
@@ -1,19 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class BlockSensor {
+class BlockSensor : MonsteraRawFile() {
     @SerializedName("sensor_radius")
     @Expose
     var sensorRadius: Number? = null
         
-
     @SerializedName("sources")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var sourcesData: MutableList<Sources>? = null
         @MonsteraBuildSetter set
 
@@ -35,6 +38,7 @@ class BlockSensor {
 
     @SerializedName("on_break")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var onBreakData: MutableList<OnBreak>? = null
         @MonsteraBuildSetter set
 
@@ -52,24 +56,21 @@ class BlockSensor {
         onBreakData = (onBreakData ?: mutableListOf()).also { it.add(OnBreak().apply(value)) }
     }
 
-    class Sources {
+    class Sources : MonsteraRawFile() {
         @SerializedName("test")
         @Expose
         var test: String? = null
             
-
         @SerializedName("subject")
         @Expose
         var subject: Subject? = null
             
-
         @SerializedName("value")
         @Expose
         var value: Boolean? = null
-            
     }
 
-    class OnBreak {
+    class OnBreak : MonsteraRawFile() {
         @SerializedName("block_list")
         @Expose
         var blockListData: MutableList<String>? = null
@@ -81,6 +82,5 @@ class BlockSensor {
         @SerializedName("on_block_broken")
         @Expose
         var onBlockBroken: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Boostable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Boostable.kt
@@ -1,23 +1,25 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class Boostable {
+class Boostable : MonsteraRawFile() {
     @SerializedName("speed_multiplier")
     @Expose
     var speedMultiplier: Number? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("boost_items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var boostItemsData: MutableList<BoostItems>? = null
         @MonsteraBuildSetter set
 
@@ -37,20 +39,17 @@ class Boostable {
         boostItemsData = (boostItemsData ?: mutableListOf()).also { it.add(BoostItems().apply(value)) }
     }
 
-    class BoostItems {
+    class BoostItems : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
             
-
         @SerializedName("damage")
         @Expose
         var damage: Number? = null
             
-
         @SerializedName("replace_item")
         @Expose
         var replaceItem: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Boss.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Boss.kt
@@ -2,17 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Boss {
-
+class Boss : MonsteraRawFile() {
     @SerializedName("should_darken_sky")
     @Expose
     var shouldDarkenSky: Boolean? = null
         
-
     @SerializedName("hud_range")
     @Expose
     var hudRange: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BreakBlocks.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BreakBlocks.kt
@@ -2,13 +2,12 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BreakBlocks {
+class BreakBlocks : MonsteraRawFile() {
     @SerializedName("breakable_blocks")
     @Expose
     var breakableBlocksData: MutableList<String>? = null
-        
 
     fun breakableBlocks(vararg value: String) {
         breakableBlocksData = (breakableBlocksData ?: mutableListOf()).also { it.addAll(value.toList()) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Breathable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Breathable.kt
@@ -2,41 +2,34 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Breathable {
+class Breathable: MonsteraRawFile() {
     @SerializedName("totalSupply")
     @Expose
     var totalSupply: Number? = null
-        
 
     @SerializedName("suffocateTime")
     @Expose
     var suffocateTime: Number? = null
         
-
     @SerializedName("breathes_water")
     @Expose
     var breathesWater: Boolean? = null
         
-
     @SerializedName("breathes_air")
     @Expose
     var breathesAir: Boolean? = null
         
-
     @SerializedName("generates_bubbles")
     @Expose
     var generatesBubbles: Boolean? = null
         
-
     @SerializedName("breathes_lava")
     @Expose
     var breathesLava: Boolean? = null
         
-
     @SerializedName("inhale_time")
     @Expose
     var inhaleTime: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Breedable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Breedable.kt
@@ -1,30 +1,31 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Breedable {
+class Breedable : MonsteraRawFile() {
     @SerializedName("require_tame")
     @Expose
     var requireTame: Boolean? = null
         
-
     @SerializedName("breed_items")
     @Expose
     var breedItems: String? = null
         
-
     @SerializedName("transform_to_item")
     @Expose
     var transformToItem: String? = null
         
-
     @SerializedName("breeds_with")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var breedsWithData: BreedsWith? = null
         @MonsteraBuildSetter set
 
@@ -45,6 +46,7 @@ class Breedable {
 
     @SerializedName("mutation_factor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var mutationFactorData: MutationFactor? = null
         @MonsteraBuildSetter set
 
@@ -66,17 +68,14 @@ class Breedable {
     @Expose
     var requireFullHealth: Boolean? = null
         
-
     @SerializedName("allow_sitting")
     @Expose
     var allowSitting: Boolean? = null
         
-
     @SerializedName("parent_centric_attribute_blending")
     @Expose
     var parentCentricAttributeBlendingData: MutableList<String>? = null
         
-
     fun parentCentricAttributeBlending(vararg value: String) {
         parentCentricAttributeBlendingData =
             (parentCentricAttributeBlendingData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -86,12 +85,10 @@ class Breedable {
     @Expose
     var inheritTamed: Boolean? = null
         
-
     @SerializedName("causes_pregnancy")
     @Expose
     var causesPregnancy: Boolean? = null
         
-
     @SerializedName("love_filters")
     @Expose
     var loveFiltersData: BehEntityFilter? = null
@@ -118,12 +115,10 @@ class Breedable {
     @Expose
     var mutationStrategy: String? = null
         
-
     @SerializedName("random_variant_mutation_interval")
     @Expose
     var randomVariantMutationIntervalData: MutableList<Number>? = null
         
-
     fun randomVariantMutationInterval(vararg value: Number) {
         randomVariantMutationIntervalData =
             (randomVariantMutationIntervalData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -133,7 +128,6 @@ class Breedable {
     @Expose
     var randomExtraVariantMutationIntervalData: MutableList<Number>? = null
         
-
     fun randomExtraVariantMutationInterval(vararg value: Number) {
         randomExtraVariantMutationIntervalData =
             (randomExtraVariantMutationIntervalData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -141,6 +135,7 @@ class Breedable {
 
     @SerializedName("deny_parents_variant")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var denyParentsVariantData: DenyParentsVariant? = null
         @MonsteraBuildSetter set
 
@@ -164,9 +159,9 @@ class Breedable {
     @Expose
     var blendAttributes: Boolean? = null
         
-
     @SerializedName("environment_requirements")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var environmentRequirementsData: EnvironmentRequirements? = null
         @MonsteraBuildSetter set
 
@@ -186,19 +181,18 @@ class Breedable {
         environmentRequirementsData = (environmentRequirementsData ?: EnvironmentRequirements()).apply(value)
     }
 
-    class BreedsWith {
+    class BreedsWith : MonsteraRawFile() {
         @SerializedName("mate_type")
         @Expose
         var mateType: String? = null
             
-
         @SerializedName("baby_type")
         @Expose
         var babyType: String? = null
             
-
         @SerializedName("breed_event")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var breedEventData: BreedEvent? = null
             @MonsteraBuildSetter set
 
@@ -218,57 +212,49 @@ class Breedable {
         }
     }
 
-    class BreedEvent {
+    class BreedEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class MutationFactor {
+    class MutationFactor : MonsteraRawFile() {
         @SerializedName("variant")
         @Expose
         var variant: Number? = null
             
     }
 
-    class DenyParentsVariant {
-
+    class DenyParentsVariant : MonsteraRawFile() {
         @SerializedName("chance")
         @Expose
         var chance: Number? = null
             
-
         @SerializedName("min_variant")
         @Expose
         var minVariant: Number? = null
             
-
         @SerializedName("max_variant")
         @Expose
         var maxVariant: Number? = null
             
     }
 
-    class EnvironmentRequirements {
+    class EnvironmentRequirements : MonsteraRawFile() {
         @SerializedName("blocks")
         @Expose
         var blocks: String? = null
             
-
         @SerializedName("count")
         @Expose
         var count: Number? = null
             
-
         @SerializedName("radius")
         @Expose
         var radius: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Bribeable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Bribeable.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Bribeable {
+class Bribeable : MonsteraRawFile() {
 
     @SerializedName("bribe_items")
     @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Buoyant.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Buoyant.kt
@@ -2,39 +2,33 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Buoyant {
+class Buoyant : MonsteraRawFile() {
     @SerializedName("base_buoyancy")
     @Expose
     var baseBuoyancy: Number? = null
         
-
     @SerializedName("apply_gravity")
     @Expose
     var applyGravity: Boolean? = null
         
-
     @SerializedName("simulate_waves")
     @Expose
     var simulateWaves: Boolean? = null
         
-
     @SerializedName("big_wave_probability")
     @Expose
     var bigWaveProbability: Number? = null
         
-
     @SerializedName("big_wave_speed")
     @Expose
     var bigWaveSpeed: Number? = null
         
-
     @SerializedName("liquid_blocks")
     @Expose
     var liquidBlocksData: MutableList<String>? = null
         
-
     fun liquidBlocks(vararg value: String) {
         liquidBlocksData = (liquidBlocksData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
@@ -42,5 +36,4 @@ class Buoyant {
     @SerializedName("drag_down_on_buoyancy_removed")
     @Expose
     var dragDownOnBuoyancyRemoved: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BurnsInDaylight.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/BurnsInDaylight.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class BurnsInDaylight
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class BurnsInDaylight : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanClimb.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanClimb.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class CanClimb
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class CanClimb : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanFly.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanFly.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class CanFly
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class CanFly : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanJoinRaid.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanJoinRaid.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class CanJoinRaid
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class CanJoinRaid : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanPowerJump.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CanPowerJump.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class CanPowerJump
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class CanPowerJump : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CelebrateHunt.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CelebrateHunt.kt
@@ -1,8 +1,11 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
@@ -29,19 +32,17 @@ class CelebrateHunt {
     @Expose
     var broadcast: Boolean? = null
         
-
     @SerializedName("duration")
     @Expose
     var duration: Number? = null
         
-
     @SerializedName("celebrate_sound")
     @Expose
     var celebrateSound: String? = null
         
-
     @SerializedName("sound_interval")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var soundIntervalData: SoundInterval? = null
         @MonsteraBuildSetter set
 
@@ -65,15 +66,13 @@ class CelebrateHunt {
     var radius: Number? = null
         
 
-    class SoundInterval {
+    class SoundInterval : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
             
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CollisionBox.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CollisionBox.kt
@@ -2,17 +2,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class CollisionBox {
+class CollisionBox : MonsteraRawFile() {
 
     @SerializedName("width")
     @Expose
     var width: Number? = null
         
-
     @SerializedName("height")
     @Expose
     var height: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CombatRegeneration.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CombatRegeneration.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class CombatRegeneration
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class CombatRegeneration : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ConditionalBandwidthOptimization.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ConditionalBandwidthOptimization.kt
@@ -1,14 +1,19 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class ConditionalBandwidthOptimization {
+class ConditionalBandwidthOptimization : MonsteraRawFile() {
     @SerializedName("default_values")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var defaultValuesData: DefaultValues? = null
         @MonsteraBuildSetter set
 
@@ -30,6 +35,7 @@ class ConditionalBandwidthOptimization {
 
     @SerializedName("conditional_values")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var conditionalValuesData: MutableList<ConditionalValues>? = null
         @MonsteraBuildSetter set
 
@@ -50,7 +56,7 @@ class ConditionalBandwidthOptimization {
             (conditionalValuesData ?: mutableListOf()).also { it.add(ConditionalValues().apply(value)) }
     }
 
-    class DefaultValues {
+    class DefaultValues : MonsteraRawFile() {
         @SerializedName("max_optimized_distance")
         @Expose
         var maxOptimizedDistance: Number? = null
@@ -67,7 +73,7 @@ class ConditionalBandwidthOptimization {
             
     }
 
-    class ConditionalValues {
+    class ConditionalValues : MonsteraRawFile() {
         @SerializedName("max_optimized_distance")
         @Expose
         var maxOptimizedDistance: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CustomHitTest.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/CustomHitTest.kt
@@ -1,13 +1,17 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class CustomHitTest {
+class CustomHitTest : MonsteraRawFile() {
     @SerializedName("hitboxes")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var hitboxesData: MutableList<Hitboxes>? = null
         @MonsteraBuildSetter set
 
@@ -26,23 +30,19 @@ class CustomHitTest {
         hitboxesData = (hitboxesData ?: mutableListOf()).also { it.add(Hitboxes().apply(value)) }
     }
 
-    class Hitboxes {
-
+    class Hitboxes : MonsteraRawFile() {
         @SerializedName("width")
         @Expose
         var width: Number? = null
             
-
         @SerializedName("height")
         @Expose
         var height: Number? = null
             
-
         @SerializedName("pivot")
         @Expose
         var pivotData: MutableList<Number>? = null
             
-
         fun pivot(vararg value: Number) {
             pivotData = (pivotData ?: mutableListOf()).also { it.addAll(value.toList()) }
         }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/DamageOverTime.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/DamageOverTime.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class DamageOverTime {
+class DamageOverTime : MonsteraRawFile() {
     @SerializedName("damage_per_hurt")
     @Expose
     var damagePerHurt: Number? = null
         
-
     @SerializedName("time_between_hurt")
     @Expose
     var timeBetweenHurt: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/DamageSensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/DamageSensor.kt
@@ -3,16 +3,21 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.DamageType
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class DamageSensor {
+class DamageSensor : MonsteraRawFile() {
     @SerializedName("triggers")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var triggersData: MutableList<Trigger>? = null
         @MonsteraBuildSetter set
 
@@ -33,11 +38,12 @@ class DamageSensor {
         triggersData = (triggersData ?: mutableListOf()).also { it.add(Trigger().apply(value)) }
     }
 
-    class Trigger {
+    class Trigger : MonsteraRawFile() {
         @SerializedName("on_damage")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var onDamageData: OnDamage? = null
-            
+            @MonsteraBuildSetter set
 
         /**
          *
@@ -69,8 +75,7 @@ class DamageSensor {
         var onDamageSoundEvent: String? = null
     }
 
-    class OnDamage {
-
+    class OnDamage : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Dash.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Dash.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Dash {
+class Dash : MonsteraRawFile() {
     @SerializedName("cooldown_time")
     @Expose
     var cooldownTime: Number? = null
         
-
     @SerializedName("horizontal_momentum")
     @Expose
     var horizontalMomentum: Number? = null
         
-
     @SerializedName("vertical_momentum")
     @Expose
     var verticalMomentum: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Despawn.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Despawn.kt
@@ -1,14 +1,18 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class Despawn {
+class Despawn : MonsteraRawFile() {
     @SerializedName("despawn_from_distance")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var despawnFromDistanceData: DespawnFromDistance? = null
         @MonsteraBuildSetter set
 
@@ -46,7 +50,6 @@ class Despawn {
     @SerializedName("remove_child_entities")
     @Expose
     var removeChildEntities: Boolean? = null
-        
 
-    class DespawnFromDistance
+    class DespawnFromDistance : MonsteraRawFile()
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/DryingOutTimer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/DryingOutTimer.kt
@@ -1,23 +1,25 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class DryingOutTimer {
+class DryingOutTimer : MonsteraRawFile() {
     @SerializedName("total_time")
     @Expose
     var totalTime: Number? = null
         
-
     @SerializedName("water_bottle_refill_time")
     @Expose
     var waterBottleRefillTime: Number? = null
         
-
     @SerializedName("dried_out_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var driedOutEventData: DriedOutEvent? = null
         @MonsteraBuildSetter set
 
@@ -37,6 +39,7 @@ class DryingOutTimer {
 
     @SerializedName("stopped_drying_out_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var stoppedDryingOutEventData: StoppedDryingOutEvent? = null
         @MonsteraBuildSetter set
 
@@ -56,6 +59,7 @@ class DryingOutTimer {
 
     @SerializedName("recover_after_dried_out_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var recoverAfterDriedOutEventData: RecoverAfterDriedOutEvent? = null
         @MonsteraBuildSetter set
 
@@ -73,27 +77,21 @@ class DryingOutTimer {
         recoverAfterDriedOutEventData = (recoverAfterDriedOutEventData ?: RecoverAfterDriedOutEvent()).apply(value)
     }
 
-    class DriedOutEvent {
-
+    class DriedOutEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 
-    class StoppedDryingOutEvent {
-
+    class StoppedDryingOutEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 
-    class RecoverAfterDriedOutEvent {
-
+    class RecoverAfterDriedOutEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Dweller.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Dweller.kt
@@ -2,46 +2,38 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Dweller {
+class Dweller : MonsteraRawFile() {
     @SerializedName("dwelling_type")
     @Expose
     var dwellingType: String? = null
         
-
     @SerializedName("dweller_role")
     @Expose
     var dwellerRole: String? = null
         
-
     @SerializedName("update_interval_base")
     @Expose
     var updateIntervalBase: Number? = null
         
-
     @SerializedName("update_interval_variant")
     @Expose
     var updateIntervalVariant: Number? = null
         
-
     @SerializedName("can_find_poi")
     @Expose
     var canFindPoi: Boolean? = null
         
-
     @SerializedName("can_migrate")
     @Expose
     var canMigrate: Boolean? = null
         
-
     @SerializedName("first_founding_reward")
     @Expose
     var firstFoundingReward: Number? = null
         
-
     @SerializedName("preferred_profession")
     @Expose
     var preferredProfession: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EconomyTradeTable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EconomyTradeTable.kt
@@ -2,10 +2,11 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.trading.BehEconomyTrades
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class EconomyTradeTable {
+class EconomyTradeTable : MonsteraRawFile() {
     @SerializedName("display_name")
     @Expose
     var displayName: String? = null
@@ -37,16 +38,13 @@ class EconomyTradeTable {
     @Expose
     var newScreen: Boolean? = null
 
-
     @SerializedName("persist_trades")
     @Expose
     var persistTrades: Boolean? = null
 
-
     @SerializedName("cured_discount")
     @Expose
     var curedDiscountData: MutableList<Number>? = null
-
 
     fun curedDiscount(vararg value: Number) {
         curedDiscountData = (curedDiscountData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -55,7 +53,6 @@ class EconomyTradeTable {
     @SerializedName("max_cured_discount")
     @Expose
     var maxCuredDiscountData: MutableList<Number>? = null
-
 
     fun maxCuredDiscount(vararg value: Number) {
         maxCuredDiscountData = (maxCuredDiscountData ?: mutableListOf()).also { it.addAll(value.toList()) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EntitySensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EntitySensor.kt
@@ -3,20 +3,19 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class EntitySensor {
+class EntitySensor : MonsteraRawFile() {
     @SerializedName("sensor_range")
     @Expose
     var sensorRange: Number? = null
         
-
     @SerializedName("relative_range")
     @Expose
     var relativeRange: Boolean? = null
         
-
     @SerializedName("event_filters")
     @Expose
     var eventFiltersData: BehEntityFilter? = null
@@ -39,14 +38,11 @@ class EntitySensor {
     @Expose
     var event: String? = null
         
-
     @SerializedName("minimum_count")
     @Expose
     var minimumCount: Number? = null
         
-
     @SerializedName("require_all")
     @Expose
     var requireAll: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EnvironmentSensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EnvironmentSensor.kt
@@ -1,14 +1,18 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class EnvironmentSensor {
+class EnvironmentSensor : MonsteraRawFile() {
     @SerializedName("triggers")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var triggersData: MutableList<Triggers>? = null
         @MonsteraBuildSetter set
 
@@ -41,7 +45,7 @@ class EnvironmentSensor {
         triggersData = (triggersData ?: mutableListOf()).also { it.add(Triggers().apply(value)) }
     }
 
-    class Triggers {
+    class Triggers : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null
@@ -66,6 +70,5 @@ class EnvironmentSensor {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EquipItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/EquipItem.kt
@@ -1,13 +1,17 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class EquipItem {
+class EquipItem : MonsteraRawFile() {
     @SerializedName("excluded_items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var excludedItemsData: MutableList<ExcludedItems>? = null
         @MonsteraBuildSetter set
 
@@ -25,10 +29,9 @@ class EquipItem {
         excludedItemsData = (excludedItemsData ?: mutableListOf()).also { it.add(ExcludedItems().apply(value)) }
     }
 
-    class ExcludedItems {
+    class ExcludedItems : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Equipment.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Equipment.kt
@@ -1,13 +1,16 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class Equipment {
+class Equipment : MonsteraRawFile() {
     @SerializedName("table")
     @Expose
     var table: String? = null
@@ -32,6 +35,7 @@ class Equipment {
 
     @SerializedName("slot_drop_chance")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var slotDropChanceData: MutableList<SlotDropChance>? = null
         @MonsteraBuildSetter set
 
@@ -50,15 +54,13 @@ class Equipment {
         slotDropChanceData = (slotDropChanceData ?: mutableListOf()).also { it.add(SlotDropChance().apply(value)) }
     }
 
-    class SlotDropChance {
+    class SlotDropChance : MonsteraRawFile() {
         @SerializedName("slot")
         @Expose
         var slot: String? = null
             
-
         @SerializedName("drop_chance")
         @Expose
         var dropChance: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Equippable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Equippable.kt
@@ -1,13 +1,18 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class Equippable {
+class Equippable : MonsteraRawFile() {
     @SerializedName("slots")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var slotsData: MutableList<Slots>? = null
         @MonsteraBuildSetter set
 
@@ -26,29 +31,26 @@ class Equippable {
         slotsData = (slotsData ?: mutableListOf()).also { it.add(Slots().apply(value)) }
     }
 
-    class Slots {
-
+    class Slots : MonsteraRawFile() {
         @SerializedName("slot")
         @Expose
         var slot: Number? = null
             
-
         @SerializedName("item")
         @Expose
         var item: String? = null
             
-
         @SerializedName("accepted_items")
         @Expose
         var acceptedItemsData: MutableList<String>? = null
             
-
         fun acceptedItems(vararg value: String) {
             acceptedItemsData = (acceptedItemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
         }
 
         @SerializedName("on_equip")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var onEquipData: OnEquip? = null
             @MonsteraBuildSetter set
 
@@ -68,7 +70,9 @@ class Equippable {
 
         @SerializedName("on_unequip")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var onUnequipData: OnUnequip? = null
+            @MonsteraBuildSetter set
             
 
         /**
@@ -86,19 +90,15 @@ class Equippable {
         }
     }
 
-    class OnEquip {
-
+    class OnEquip : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 
-    class OnUnequip {
-
+    class OnUnequip : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ExhaustionValues.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ExhaustionValues.kt
@@ -2,51 +2,42 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ExhaustionValues {
+class ExhaustionValues : MonsteraRawFile() {
     @SerializedName("heal")
     @Expose
     var heal: Number? = null
         
-
     @SerializedName("jump")
     @Expose
     var jump: Number? = null
         
-
     @SerializedName("sprint_jump")
     @Expose
     var sprintJump: Number? = null
         
-
     @SerializedName("mine")
     @Expose
     var mine: Number? = null
         
-
     @SerializedName("attack")
     @Expose
     var attack: Number? = null
         
-
     @SerializedName("damage")
     @Expose
     var damage: Number? = null
         
-
     @SerializedName("walk")
     @Expose
     var walk: Number? = null
         
-
     @SerializedName("sprint")
     @Expose
     var sprint: Number? = null
         
-
     @SerializedName("swim")
     @Expose
     var swim: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ExperienceReward.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ExperienceReward.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ExperienceReward {
+class ExperienceReward : MonsteraRawFile() {
     @SerializedName("on_bred")
     @Expose
     var onBred: String? = null
         
-
     @SerializedName("on_death")
     @Expose
     var onDeath: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Explode.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Explode.kt
@@ -2,41 +2,34 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Explode {
+class Explode : MonsteraRawFile() {
     @SerializedName("fuse_length")
     @Expose
     var fuseLength: Number? = null
         
-
     @SerializedName("fuse_lit")
     @Expose
     var fuseLit: Boolean? = null
         
-
     @SerializedName("power")
     @Expose
     var power: Number? = null
         
-
     @SerializedName("causes_fire")
     @Expose
     var causesFire: Boolean? = null
         
-
     @SerializedName("destroy_affected_by_griefing")
     @Expose
     var destroyAffectedByGriefing: Boolean? = null
         
-
     @SerializedName("fire_affected_by_griefing")
     @Expose
     var fireAffectedByGriefing: Boolean? = null
         
-
     @SerializedName("max_resistance")
     @Expose
     var maxResistance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/FireImmune.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/FireImmune.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class FireImmune
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class FireImmune : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Flocking.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Flocking.kt
@@ -2,96 +2,78 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Flocking {
+class Flocking : MonsteraRawFile() {
     @SerializedName("in_water")
     @Expose
     var inWater: Boolean? = null
         
-
     @SerializedName("match_variants")
     @Expose
     var matchVariants: Boolean? = null
         
-
     @SerializedName("use_center_of_mass")
     @Expose
     var useCenterOfMass: Boolean? = null
         
-
     @SerializedName("low_flock_limit")
     @Expose
     var lowFlockLimit: Number? = null
         
-
     @SerializedName("high_flock_limit")
     @Expose
     var highFlockLimit: Number? = null
         
-
     @SerializedName("goal_weight")
     @Expose
     var goalWeight: Number? = null
         
-
     @SerializedName("loner_chance")
     @Expose
     var lonerChance: Number? = null
         
-
     @SerializedName("influence_radius")
     @Expose
     var influenceRadius: Number? = null
         
-
     @SerializedName("breach_influence")
     @Expose
     var breachInfluence: Number? = null
         
-
     @SerializedName("separation_weight")
     @Expose
     var separationWeight: Number? = null
         
-
     @SerializedName("separation_threshold")
     @Expose
     var separationThreshold: Number? = null
         
-
     @SerializedName("cohesion_weight")
     @Expose
     var cohesionWeight: Number? = null
         
-
     @SerializedName("cohesion_threshold")
     @Expose
     var cohesionThreshold: Number? = null
         
-
     @SerializedName("innner_cohesion_threshold")
     @Expose
     var innnerCohesionThreshold: Number? = null
         
-
     @SerializedName("min_height")
     @Expose
     var minHeight: Number? = null
         
-
     @SerializedName("max_height")
     @Expose
     var maxHeight: Number? = null
         
-
     @SerializedName("block_distance")
     @Expose
     var blockDistance: Number? = null
         
-
     @SerializedName("block_weight")
     @Expose
     var blockWeight: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/FollowRange.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/FollowRange.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class FollowRange {
+class FollowRange : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null
         
-
     @SerializedName("max")
     @Expose
     var max: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/GameEventMovementTracking.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/GameEventMovementTracking.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class GameEventMovementTracking {
+class GameEventMovementTracking : MonsteraRawFile() {
     @SerializedName("emit_flap")
     @Expose
     var emitFlap: Boolean? = null
-        
 
     @SerializedName("emit_move")
     @Expose
     var emitMove: Boolean? = null
-        
 
     @SerializedName("emit_swim")
     @Expose
     var emitSwim: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Genetics.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Genetics.kt
@@ -1,19 +1,23 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Genetics {
+class Genetics : MonsteraRawFile() {
     @SerializedName("mutation_rate")
     @Expose
     var mutationRate: Number? = null
         
-
     @SerializedName("genes")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var genesData: MutableList<Genes>? = null
         @MonsteraBuildSetter set
 
@@ -32,19 +36,18 @@ class Genetics {
         genesData = (genesData ?: mutableListOf()).also { it.add(Genes().apply(value)) }
     }
 
-    class Genes {
+    class Genes : MonsteraRawFile() {
         @SerializedName("name")
         @Expose
         var name: String? = null
             
-
         @SerializedName("use_simplified_breeding")
         @Expose
         var useSimplifiedBreeding: Boolean? = null
             
-
         @SerializedName("allele_range")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var alleleRangeData: AlleleRange? = null
             @MonsteraBuildSetter set
 
@@ -65,6 +68,7 @@ class Genetics {
 
         @SerializedName("genetic_variants")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var geneticVariantsData: MutableList<GeneticVariants>? = null
             @MonsteraBuildSetter set
 
@@ -83,23 +87,20 @@ class Genetics {
         }
     }
 
-    class AlleleRange {
-
+    class AlleleRange : MonsteraRawFile() {
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
-            
 
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
     class GeneticVariants {
-
         @SerializedName("main_allele")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var mainAlleleData: MainAllele? = null
             @MonsteraBuildSetter set
 
@@ -120,6 +121,7 @@ class Genetics {
 
         @SerializedName("birth_event")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var birthEventData: BirthEvent? = null
             
 
@@ -139,29 +141,24 @@ class Genetics {
         }
     }
 
-    class MainAllele {
+    class MainAllele : MonsteraRawFile() {
 
         @SerializedName("range_min")
         @Expose
         var rangeMin: Number? = null
             
-
         @SerializedName("range_max")
         @Expose
         var rangeMax: Number? = null
-            
     }
 
-    class BirthEvent {
-
+    class BirthEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Giveable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Giveable.kt
@@ -1,15 +1,19 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Giveable {
+class Giveable : MonsteraRawFile() {
 
     @SerializedName("triggers")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var triggersData: Triggers? = null
         @MonsteraBuildSetter set
 
@@ -27,24 +31,22 @@ class Giveable {
         triggersData = (triggersData ?: Triggers()).apply(value)
     }
 
-    class Triggers {
-
+    class Triggers : MonsteraRawFile() {
         @SerializedName("cooldown")
         @Expose
         var cooldown: Number? = null
             
-
         @SerializedName("items")
         @Expose
         var itemsData: MutableList<String>? = null
             
-
         fun items(vararg value: String) {
             itemsData = (itemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
         }
 
         @SerializedName("on_give")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var onGiveData: OnGive? = null
             @MonsteraBuildSetter set
 
@@ -64,16 +66,13 @@ class Giveable {
         }
     }
 
-    class OnGive {
-
+    class OnGive : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/GroupSize.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/GroupSize.kt
@@ -3,15 +3,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class GroupSize {
+class GroupSize : MonsteraRawFile() {
     @SerializedName("radius")
     @Expose
     var radius: Number? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/GrowsCrop.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/GrowsCrop.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class GrowsCrop {
+class GrowsCrop : MonsteraRawFile() {
     @SerializedName("charges")
     @Expose
     var charges: Number? = null
         
-
     @SerializedName("chance")
     @Expose
     var chance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Healable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Healable.kt
@@ -1,14 +1,18 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class Healable {
+class Healable : MonsteraRawFile() {
     @SerializedName("items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var itemsData: MutableList<Items>? = null
         @MonsteraBuildSetter set
 
@@ -53,15 +57,13 @@ class Healable {
         filtersData = (filtersData ?: BehEntityFilter()).apply(value)
     }
 
-    class Items {
+    class Items : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
             
-
         @SerializedName("heal_amount")
         @Expose
         var healAmount: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Health.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Health.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Health {
+class Health : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null
-        
 
     @SerializedName("max")
     @Expose
     var max: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Heartbeat.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Heartbeat.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Heartbeat {
+class Heartbeat : MonsteraRawFile() {
     @SerializedName("interval")
     @Expose
     var interval: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Hide.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Hide.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class Hide
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class Hide : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Home.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Home.kt
@@ -9,12 +9,10 @@ class Home {
     @Expose
     var restrictionRadius: Number? = null
         
-
     @SerializedName("home_block_list")
     @Expose
     var homeBlockListData: MutableList<String>? = null
         
-
     fun homeBlockList(vararg value: String) {
         homeBlockListData = (homeBlockListData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/HurtOnCondition.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/HurtOnCondition.kt
@@ -1,15 +1,19 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.DamageType
 
-class HurtOnCondition {
+class HurtOnCondition : MonsteraRawFile() {
     @SerializedName("damage_conditions")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var damageConditionsData: MutableList<DamageConditions>? = null
         @MonsteraBuildSetter set
 
@@ -28,8 +32,8 @@ class HurtOnCondition {
         damageConditionsData =
             (damageConditionsData ?: mutableListOf()).also { it.add(DamageConditions().apply(value)) }
     }
-    class DamageConditions {
 
+    class DamageConditions : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null
@@ -55,11 +59,9 @@ class HurtOnCondition {
         @SerializedName("cause")
         @Expose
         var cause: DamageType? = null
-            
 
         @SerializedName("damage_per_tick")
         @Expose
         var damagePerTick: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/InputGroundControlled.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/InputGroundControlled.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class InputGroundControlled
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class InputGroundControlled : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/InsideBlockNotifier.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/InsideBlockNotifier.kt
@@ -1,14 +1,19 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
 class InsideBlockNotifier {
     @SerializedName("block_list")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var blockListData: MutableList<BlockList>? = null
         @MonsteraBuildSetter set
 
@@ -25,9 +30,10 @@ class InsideBlockNotifier {
         blockListData = (blockListData ?: mutableListOf()).also { it.add(BlockList().apply(value)) }
     }
 
-    class BlockList {
+    class BlockList : MonsteraRawFile() {
         @SerializedName("block")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var blockData: Block? = null
             @MonsteraBuildSetter set
 
@@ -47,6 +53,7 @@ class InsideBlockNotifier {
 
         @SerializedName("entered_block_event")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var enteredBlockEventData: EnteredBlockEvent? = null
             @MonsteraBuildSetter set
 
@@ -67,6 +74,7 @@ class InsideBlockNotifier {
 
         @SerializedName("exited_block_event")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var exitedBlockEventData: ExitedBlockEvent? = null
             @MonsteraBuildSetter set
 
@@ -86,15 +94,14 @@ class InsideBlockNotifier {
         }
     }
 
-    class Block {
-
+    class Block : MonsteraRawFile() {
         @SerializedName("name")
         @Expose
         var name: String? = null
-            
 
         @SerializedName("states")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var statesData: States? = null
             @MonsteraBuildSetter set
 
@@ -113,36 +120,30 @@ class InsideBlockNotifier {
         }
     }
 
-    class States {
+    class States : MonsteraRawFile() {
         @SerializedName("drag_down")
         @Expose
         var dragDown: Boolean? = null
             
     }
 
-    class EnteredBlockEvent {
-
+    class EnteredBlockEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class ExitedBlockEvent {
-
+    class ExitedBlockEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Insomnia.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Insomnia.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Insomnia {
-
+class Insomnia : MonsteraRawFile() {
     @SerializedName("days_until_insomnia")
     @Expose
     var daysUntilInsomnia: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/InstantDespawn.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/InstantDespawn.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class InstantDespawn {
+class InstantDespawn : MonsteraRawFile() {
     @SerializedName("remove_child_entities")
     @Expose
     var removeChildEntities: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Interact.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Interact.kt
@@ -1,18 +1,22 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class Interact {
-
+class Interact : MonsteraRawFile() {
     @SerializedName("interactions")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var interactionsData: MutableList<Interaction>? = null
         @MonsteraBuildSetter set
 
@@ -39,10 +43,11 @@ class Interact {
         interactionsData = (interactionsData ?: mutableListOf()).also { it.add(Interaction().apply(value)) }
     }
 
-    class Interaction {
+    class Interaction : MonsteraRawFile() {
 
         @SerializedName("on_interact")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var onInteractData: OnInteract? = null
             @MonsteraBuildSetter set
 
@@ -139,8 +144,7 @@ class Interact {
         }
     }
 
-    class OnInteract {
-
+    class OnInteract : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Inventory.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Inventory.kt
@@ -2,31 +2,26 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Inventory {
+class Inventory : MonsteraRawFile() {
     @SerializedName("inventory_size")
     @Expose
     var inventorySize: Number? = null
-        
 
     @SerializedName("container_type")
     @Expose
     var containerType: String? = null
-        
 
     @SerializedName("can_be_siphoned_from")
     @Expose
     var canBeSiphonedFrom: Boolean? = null
-        
 
     @SerializedName("additional_slots_per_strength")
     @Expose
     var additionalSlotsPerStrength: Number? = null
-        
 
     @SerializedName("private")
     @Expose
     var private: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsBaby.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsBaby.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsBaby
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsBaby : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsCharged.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsCharged.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsCharged
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsCharged : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsChested.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsChested.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsChested
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsChested : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsDyeable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsDyeable.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class IsDyeable {
+class IsDyeable : MonsteraRawFile() {
     @SerializedName("interact_text")
     @Expose
     var interactText: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsHiddenWhenInvisible.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsHiddenWhenInvisible.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsHiddenWhenInvisible
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsHiddenWhenInvisible: MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsIgnited.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsIgnited.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsIgnited
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsIgnited : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsIllagerCaptain.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsIllagerCaptain.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsIllagerCaptain
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsIllagerCaptain : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsPregnant.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsPregnant.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsPregnant
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsPregnant : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsSaddled.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsSaddled.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsSaddled
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsSaddled : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsShaking.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsShaking.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsShaking
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsShaking : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsSheared.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsSheared.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsSheared
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsSheared : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsStunned.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsStunned.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsStunned
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsStunned : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsTamed.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/IsTamed.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class IsTamed
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class IsTamed : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ItemControllable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ItemControllable.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemControllable {
+class ItemControllable : MonsteraRawFile() {
     @SerializedName("control_items")
     @Expose
     var controlItems: String? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ItemHopper.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ItemHopper.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class ItemHopper
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class ItemHopper : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/JumpDynamic.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/JumpDynamic.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class JumpDynamic
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class JumpDynamic : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/JumpStatic.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/JumpStatic.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class JumpStatic {
+class JumpStatic : MonsteraRawFile() {
     @SerializedName("jump_power")
     @Expose
     var jumpPower: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Leashable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Leashable.kt
@@ -1,34 +1,34 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Leashable {
+class Leashable : MonsteraRawFile() {
     @SerializedName("soft_distance")
     @Expose
     var softDistance: Number? = null
-        
 
     @SerializedName("hard_distance")
     @Expose
     var hardDistance: Number? = null
-        
 
     @SerializedName("max_distance")
     @Expose
     var maxDistance: Number? = null
-        
 
     @SerializedName("can_be_stolen")
     @Expose
     var canBeStolen: Boolean? = null
-        
 
     @SerializedName("on_leash")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onLeashData: OnLeash? = null
         @MonsteraBuildSetter set
 
@@ -49,6 +49,7 @@ class Leashable {
 
     @SerializedName("on_unleash")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onUnleashData: OnUnleash? = null
         @MonsteraBuildSetter set
 
@@ -67,27 +68,25 @@ class Leashable {
         onUnleashData = (onUnleashData ?: OnUnleash()).apply(value)
     }
 
-    class OnLeash {
+    class OnLeash : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
+
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
+
     }
 
-    class OnUnleash {
+    class OnUnleash : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
 
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Lookat.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Lookat.kt
@@ -3,25 +3,23 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class Lookat {
+class Lookat : MonsteraRawFile() {
     @SerializedName("search_radius")
     @Expose
     var searchRadius: Number? = null
         
-
     @SerializedName("set_target")
     @Expose
     var setTarget: Boolean? = null
         
-
     @SerializedName("look_cooldown")
     @Expose
     var lookCooldown: Number? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Loot.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Loot.kt
@@ -2,10 +2,11 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.loot.BehLootTables
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class Loot {
+class Loot : MonsteraRawFile() {
     @SerializedName("table")
     @Expose
     var table: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ManagedWanderingTrader.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ManagedWanderingTrader.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class ManagedWanderingTrader
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class ManagedWanderingTrader : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MobEffect.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MobEffect.kt
@@ -3,25 +3,23 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class MobEffect {
+class MobEffect : MonsteraRawFile() {
     @SerializedName("effect_range")
     @Expose
     var effectRange: Number? = null
         
-
     @SerializedName("mob_effect")
     @Expose
     var mobEffect: String? = null
         
-
     @SerializedName("effect_time")
     @Expose
     var effectTime: Number? = null
         
-
     @SerializedName("entity_filter")
     @Expose
     var entityFilterData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementAmphibious.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementAmphibious.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class MovementAmphibious {
-
+class MovementAmphibious : MonsteraRawFile() {
     @SerializedName("max_turn")
     @Expose
     var maxTurn: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementBasic.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementBasic.kt
@@ -2,12 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class MovementBasic {
-
+class MovementBasic : MonsteraRawFile() {
     @SerializedName("max_turn")
     @Expose
     var maxTurn: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementFly.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementFly.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class MovementFly
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class MovementFly : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementGeneric.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementGeneric.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class MovementGeneric
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class MovementGeneric : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementGlide.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementGlide.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class MovementGlide {
+class MovementGlide : MonsteraRawFile() {
     @SerializedName("start_speed")
     @Expose
     var startSpeed: Number? = null
         
-
     @SerializedName("speed_when_turning")
     @Expose
     var speedWhenTurning: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementHover.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementHover.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class MovementHover
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class MovementHover : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementJump.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementJump.kt
@@ -2,15 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class MovementJump {
+class MovementJump : MonsteraRawFile() {
     @SerializedName("jump_delay")
     @Expose
     var jumpDelayData: MutableList<Number>? = null
         
-
     @Components.VanillaComponentMarker
     fun jumpDelay(vararg value: Number) {
         jumpDelayData = (jumpDelayData ?: mutableListOf()).also { it.addAll(value.toList()) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementSkip.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementSkip.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class MovementSkip
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class MovementSkip : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementSway.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/MovementSway.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class MovementSway {
+class MovementSway : MonsteraRawFile() {
     @SerializedName("sway_amplitude")
     @Expose
     var swayAmplitude: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Nameable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Nameable.kt
@@ -1,24 +1,27 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Nameable {
+class Nameable: MonsteraRawFile() {
     @SerializedName("always_show")
     @Expose
     var alwaysShow: Boolean? = null
         
-
     @SerializedName("allow_name_tag_renaming")
     @Expose
     var allowNameTagRenaming: Boolean? = null
         
-
     @SerializedName("default_trigger")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var defaultTriggerData: DefaultTrigger? = null
         @MonsteraBuildSetter set
 
@@ -39,6 +42,7 @@ class Nameable {
 
     @SerializedName("name_actions")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var nameActionsData: MutableList<NameActions>? = null
         @MonsteraBuildSetter set
 
@@ -56,26 +60,24 @@ class Nameable {
         nameActionsData = (nameActionsData ?: mutableListOf()).also { it.add(NameActions().apply(value)) }
     }
 
-    class DefaultTrigger {
+    class DefaultTrigger: MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class NameActions {
+    class NameActions: MonsteraRawFile() {
         @SerializedName("name_filter")
         @Expose
         var nameFilter: String? = null
             
-
         @SerializedName("on_named")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var onNamedData: OnNamed? = null
             @MonsteraBuildSetter set
 
@@ -95,15 +97,13 @@ class Nameable {
         }
     }
 
-    class OnNamed {
+    class OnNamed: MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/NavigationClimb.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/NavigationClimb.kt
@@ -1,10 +1,13 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class NavigationComp {
+class NavigationComp: MonsteraRawFile() {
     @SerializedName("can_path_over_water")
     @Expose
     var canPathOverWater: Boolean? = null
@@ -79,6 +82,7 @@ class NavigationComp {
 
     @SerializedName("blocks_to_avoid")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var blocksToAvoid: MutableList<Block>? = null
         @MonsteraBuildSetter set
 
@@ -89,7 +93,7 @@ class NavigationComp {
         }
     }
 
-    open class Block {
+    open class Block : MonsteraRawFile() {
         @SerializedName("name")
         @Expose
         var name: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnFriendlyAnger.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnFriendlyAnger.kt
@@ -2,18 +2,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class OnFriendlyAnger {
-
+class OnFriendlyAnger : MonsteraRawFile() {
     @SerializedName("event")
     @Expose
     var event: String? = null
         
-
     @SerializedName("target")
     @Expose
     var target: Subject? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnHurt.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnHurt.kt
@@ -2,17 +2,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class OnHurt {
+class OnHurt : MonsteraRawFile() {
     @SerializedName("event")
     @Expose
     var event: String? = null
         
-
     @SerializedName("target")
     @Expose
     var target: Subject? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnHurtByPlayer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnHurtByPlayer.kt
@@ -2,17 +2,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class OnHurtByPlayer {
+class OnHurtByPlayer : MonsteraRawFile() {
     @SerializedName("event")
     @Expose
     var event: String? = null
         
-
     @SerializedName("target")
     @Expose
     var target: Subject? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnTargetAcquired.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnTargetAcquired.kt
@@ -3,21 +3,20 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class OnTargetAcquired {
+class OnTargetAcquired : MonsteraRawFile() {
     @SerializedName("event")
     @Expose
     var event: String? = null
         
-
     @SerializedName("target")
     @Expose
     var target: Subject? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnTargetEscape.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnTargetEscape.kt
@@ -3,21 +3,20 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class OnTargetEscape {
+class OnTargetEscape : MonsteraRawFile() {
     @SerializedName("event")
     @Expose
     var event: String? = null
         
-
     @SerializedName("target")
     @Expose
     var target: Subject? = null
         
-
     @SerializedName("filters")
     @Expose
     var filtersData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnWakeWithOwner.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OnWakeWithOwner.kt
@@ -2,18 +2,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class OnWakeWithOwner {
-
+class OnWakeWithOwner : MonsteraRawFile() {
     @SerializedName("event")
     @Expose
     var event: String? = null
         
-
     @SerializedName("target")
     @Expose
     var target: Subject? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OutOfControl.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/OutOfControl.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class OutOfControl
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class OutOfControl : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Persistent.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Persistent.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class Persistent
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class Persistent : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Physics.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Physics.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Physics {
+class Physics : MonsteraRawFile() {
     @SerializedName("has_gravity")
     @Expose
     var hasGravity: Boolean? = null
         
-
     @SerializedName("has_collision")
     @Expose
     var hasCollision: Boolean? = null
         
-
     @SerializedName("push_towards_closest_space")
     @Expose
     var pushTowardsClosestSpace: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerExhaustion.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerExhaustion.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class PlayerExhaustion {
+class PlayerExhaustion : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerExperience.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerExperience.kt
@@ -2,9 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class PlayerExperience {
+class PlayerExperience : MonsteraRawFile() {
 
     @SerializedName("value")
     @Expose

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerLevel.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerLevel.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class PlayerLevel {
+class PlayerLevel : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null
         
-
     @SerializedName("max")
     @Expose
     var max: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerSaturation.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PlayerSaturation.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class PlayerSaturation {
+class PlayerSaturation : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null
         
-
     @SerializedName("max")
     @Expose
     var max: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PreferredPath.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/PreferredPath.kt
@@ -1,28 +1,29 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class PreferredPath {
+class PreferredPath : MonsteraRawFile() {
     @SerializedName("max_fall_blocks")
     @Expose
     var maxFallBlocks: Number? = null
         
-
     @SerializedName("jump_cost")
     @Expose
     var jumpCost: Number? = null
         
-
     @SerializedName("default_block_cost")
     @Expose
     var defaultBlockCost: Number? = null
         
-
     @SerializedName("preferred_path_blocks")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var preferredPathBlocksData: MutableList<PreferredPathBlocks>? = null
         @MonsteraBuildSetter set
 
@@ -41,16 +42,14 @@ class PreferredPath {
             (preferredPathBlocksData ?: mutableListOf()).also { it.add(PreferredPathBlocks().apply(value)) }
     }
 
-    class PreferredPathBlocks {
+    class PreferredPathBlocks : MonsteraRawFile() {
         @SerializedName("cost")
         @Expose
         var cost: Number? = null
             
-
         @SerializedName("blocks")
         @Expose
         var blocksData: MutableList<String>? = null
-            
 
         fun blocks(vararg value: String) {
             blocksData = (blocksData ?: mutableListOf()).also { it.addAll(value.toList()) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Projectile.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Projectile.kt
@@ -1,13 +1,17 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class Projectile {
+class Projectile : MonsteraRawFile() {
     @SerializedName("on_hit")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onHitData: OnHit? = null
         @MonsteraBuildSetter set
 
@@ -27,42 +31,34 @@ class Projectile {
     @SerializedName("hit_sound")
     @Expose
     var hitSound: String? = null
-        
 
     @SerializedName("power")
     @Expose
     var power: Number? = null
-        
 
     @SerializedName("gravity")
     @Expose
     var gravity: Number? = null
-        
 
     @SerializedName("uncertainty_base")
     @Expose
     var uncertaintyBase: Number? = null
-        
 
     @SerializedName("uncertainty_multiplier")
     @Expose
     var uncertaintyMultiplier: Number? = null
-        
 
     @SerializedName("anchor")
     @Expose
     var anchor: Number? = null
-        
 
     @SerializedName("should_bounce")
     @Expose
     var shouldBounce: Boolean? = null
-        
 
     @SerializedName("offset")
     @Expose
     var offsetData: MutableList<Number>? = null
-        
 
     fun offset(vararg value: Number) {
         offsetData = (offsetData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -71,81 +67,67 @@ class Projectile {
     @SerializedName("inertia")
     @Expose
     var inertia: Number? = null
-        
 
     @SerializedName("semi_random_diff_damage")
     @Expose
     var semiRandomDiffDamage: Boolean? = null
-        
 
     @SerializedName("reflect_on_hurt")
     @Expose
     var reflectOnHurt: Boolean? = null
-        
 
     @SerializedName("angle_offset")
     @Expose
     var angleOffset: Number? = null
-        
 
     @SerializedName("liquid_inertia")
     @Expose
     var liquidInertia: Number? = null
-        
 
     @SerializedName("catch_fire")
     @Expose
     var catchFire: Boolean? = null
-        
 
     @SerializedName("destroyOnHurt")
     @Expose
     var destroyOnHurt: Boolean? = null
-        
 
     @SerializedName("crit_particle_on_hurt")
     @Expose
     var critParticleOnHurt: Boolean? = null
-        
 
     @SerializedName("homing")
     @Expose
     var homing: Boolean? = null
-        
 
     @SerializedName("hit_ground_sound")
     @Expose
     var hitGroundSound: String? = null
-        
 
     @SerializedName("stop_on_hurt")
     @Expose
     var stopOnHurt: Boolean? = null
-        
 
     @SerializedName("multiple_targets")
     @Expose
     var multipleTargets: Boolean? = null
-        
 
     @SerializedName("shoot_sound")
     @Expose
     var shootSound: String? = null
-        
 
     @SerializedName("shoot_target")
     @Expose
     var shootTarget: Boolean? = null
-        
 
     @SerializedName("is_dangerous")
     @Expose
     var isDangerous: Boolean? = null
-        
 
-    class OnHit {
+    class OnHit : MonsteraRawFile() {
         @SerializedName("impact_damage")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var impactDamageData: ImpactDamage? = null
             @MonsteraBuildSetter set
 
@@ -167,6 +149,7 @@ class Projectile {
 
         @SerializedName("stick_in_ground")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var stickInGroundData: StickInGround? = null
             @MonsteraBuildSetter set
 
@@ -186,6 +169,7 @@ class Projectile {
 
         @SerializedName("arrow_effect")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var arrowEffectData: ArrowEffect? = null
             @MonsteraBuildSetter set
 
@@ -204,11 +188,10 @@ class Projectile {
         }
     }
 
-    class ImpactDamage {
+    class ImpactDamage : MonsteraRawFile() {
         @SerializedName("damage")
         @Expose
         var damageData: MutableList<Number>? = null
-            
 
         fun damage(vararg value: Number) {
             damageData = (damageData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -217,32 +200,26 @@ class Projectile {
         @SerializedName("knockback")
         @Expose
         var knockback: Boolean? = null
-            
 
         @SerializedName("semi_random_diff_damage")
         @Expose
         var semiRandomDiffDamage: Boolean? = null
-            
 
         @SerializedName("destroy_on_hit")
         @Expose
         var destroyOnHit: Boolean? = null
-            
+
     }
 
-    class StickInGround {
-
+    class StickInGround : MonsteraRawFile() {
         @SerializedName("shake_time")
         @Expose
         var shakeTime: Number? = null
-            
     }
 
-    class ArrowEffect {
-
+    class ArrowEffect : MonsteraRawFile() {
         @SerializedName("apply_effect_to_blocking_targets")
         @Expose
         var applyEffectToBlockingTargets: Boolean? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Pushable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Pushable.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Pushable {
+class Pushable : MonsteraRawFile() {
     @SerializedName("is_pushable")
     @Expose
     var isPushable: Boolean? = null
         
-
     @SerializedName("is_pushable_by_piston")
     @Expose
     var isPushableByPiston: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RaidTrigger.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RaidTrigger.kt
@@ -1,14 +1,18 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class RaidTrigger {
+class RaidTrigger : MonsteraRawFile() {
     @SerializedName("triggered_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var triggeredEventData: TriggeredEvent? = null
         @MonsteraBuildSetter set
 
@@ -27,15 +31,13 @@ class RaidTrigger {
         triggeredEventData = (triggeredEventData ?: TriggeredEvent()).apply(value)
     }
 
-    class TriggeredEvent {
+    class TriggeredEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RailMovement.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RailMovement.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class RailMovement
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class RailMovement : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RailSensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RailSensor.kt
@@ -1,11 +1,14 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class RailSensor {
+class RailSensor : MonsteraRawFile() {
     @SerializedName("check_block_types")
     @Expose
     var checkBlockTypes: Boolean? = null
@@ -33,6 +36,7 @@ class RailSensor {
 
     @SerializedName("on_deactivate")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onDeactivateData: OnDeactivate? = null
         @MonsteraBuildSetter set
 
@@ -52,6 +56,7 @@ class RailSensor {
 
     @SerializedName("on_activate")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onActivateData: OnActivate? = null
         @MonsteraBuildSetter set
 
@@ -69,17 +74,15 @@ class RailSensor {
         onActivateData = (onActivateData ?: OnActivate()).apply(value)
     }
 
-    class OnDeactivate {
+    class OnDeactivate : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 
-    class OnActivate {
+    class OnActivate : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RavagerBlocked.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/RavagerBlocked.kt
@@ -1,19 +1,23 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class RavagerBlocked {
+class RavagerBlocked : MonsteraRawFile() {
     @SerializedName("knockback_strength")
     @Expose
     var knockbackStrength: Number? = null
         
-
     @SerializedName("reaction_choices")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var reactionChoicesData: MutableList<ReactionChoices>? = null
         @MonsteraBuildSetter set
 
@@ -31,14 +35,14 @@ class RavagerBlocked {
         reactionChoicesData = (reactionChoicesData ?: mutableListOf()).also { it.add(ReactionChoices().apply(value)) }
     }
 
-    class ReactionChoices {
+    class ReactionChoices : MonsteraRawFile() {
         @SerializedName("weight")
         @Expose
         var weight: Number? = null
             
-
         @SerializedName("value")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var valueData: Value? = null
             @MonsteraBuildSetter set
 
@@ -58,15 +62,13 @@ class RavagerBlocked {
         }
     }
 
-    class Value {
+    class Value : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Rideable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Rideable.kt
@@ -1,34 +1,34 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.Config
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class Rideable {
+class Rideable : MonsteraRawFile() {
     @SerializedName("seat_count")
     @Expose
     var seatCount: Number? = null
         
-
     @SerializedName("passenger_max_width")
     @Expose
     var passengerMaxWidth: Number? = null
         
-
     @SerializedName("interact_text")
     @Expose
     var interactText: String? = null
         
-
     @SerializedName("pull_in_entities")
     @Expose
     var pullInEntities: Boolean? = null
         
-
     @SerializedName("seats")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var seatsData: MutableList<Seats>? = null
         @MonsteraBuildSetter set
 
@@ -53,7 +53,6 @@ class Rideable {
     @Expose
     var crouchingSkipInteract: Boolean? = null
         
-
     @SerializedName("family_types")
     @Expose
     var familyTypesData: MutableList<String>? = null
@@ -93,12 +92,11 @@ class Rideable {
         config?.langFileBuilder?.addonRes?.add(key, displayText)
     }
 
-    class Seats {
+    class Seats : MonsteraRawFile() {
         @SerializedName("position")
         @Expose
         var positionData: MutableList<Number>? = null
             
-
         @Components.VanillaComponentMarker
         fun position(vararg value: Number) {
             positionData = (positionData ?: mutableListOf()).also { it.addAll(value.toList()) }
@@ -108,17 +106,14 @@ class Rideable {
         @Expose
         var minRiderCount: Number? = null
             
-
         @SerializedName("max_rider_count")
         @Expose
         var maxRiderCount: Number? = null
             
-
         @SerializedName("rotate_rider_by")
         @Expose
         var rotateRiderBy: Number? = null
             
-
         @SerializedName("lock_rider_rotation")
         @Expose
         var lockRiderRotation: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ScaleByAge.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/ScaleByAge.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ScaleByAge {
+class ScaleByAge : MonsteraRawFile() {
     @SerializedName("start_scale")
     @Expose
     var startScale: Number? = null
         
-
     @SerializedName("end_scale")
     @Expose
     var endScale: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Scheduler.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Scheduler.kt
@@ -1,17 +1,19 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class Scheduler {
+class Scheduler : MonsteraRawFile() {
     @SerializedName("min_delay_secs")
     @Expose
     var minDelaySecs: Number? = null
         
-
     @SerializedName("max_delay_secs")
     @Expose
     var maxDelaySecs: Number? = null
@@ -19,6 +21,7 @@ class Scheduler {
 
     @SerializedName("scheduled_events")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var scheduledEventsData: MutableList<ScheduledEvents>? = null
         @MonsteraBuildSetter set
 
@@ -36,8 +39,7 @@ class Scheduler {
         scheduledEventsData = (scheduledEventsData ?: mutableListOf()).also { it.add(ScheduledEvents().apply(value)) }
     }
 
-    class ScheduledEvents {
-
+    class ScheduledEvents : MonsteraRawFile() {
         @SerializedName("filters")
         @Expose
         var filtersData: MutableList<BehEntityFilter>? = null
@@ -61,6 +63,5 @@ class Scheduler {
         @SerializedName("event")
         @Expose
         var event: String? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Shareables.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Shareables.kt
@@ -1,18 +1,21 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class Shareables {
+class Shareables : MonsteraRawFile() {
     @SerializedName("singular_pickup")
     @Expose
     var singularPickup: Boolean? = null
         
-
     @SerializedName("items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var itemsData: MutableList<Items>? = null
         @MonsteraBuildSetter set
 
@@ -37,31 +40,25 @@ class Shareables {
     @Expose
     var allItems: Boolean? = null
         
-
     @SerializedName("all_items_max_amount")
     @Expose
     var allItemsMaxAmount: Number? = null
         
-
-    class Items {
+    class Items : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
             
-
         @SerializedName("want_amount")
         @Expose
         var wantAmount: Number? = null
             
-
         @SerializedName("surplus_amount")
         @Expose
         var surplusAmount: Number? = null
             
-
         @SerializedName("priority")
         @Expose
         var priority: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Shooter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Shooter.kt
@@ -1,12 +1,15 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class Shooter {
+class Shooter : MonsteraRawFile() {
     @SerializedName("def")
     @Expose
     var def: String? = null
@@ -29,6 +32,7 @@ class Shooter {
 
     @SerializedName("projectiles")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var projectilesData: MutableList<Projectiles>? = null
         @MonsteraBuildSetter set
 
@@ -52,7 +56,7 @@ class Shooter {
     @Expose
     var magic: Boolean? = null
 
-    class Projectiles {
+    class Projectiles : MonsteraRawFile() {
         @SerializedName("def")
         @Expose
         var def: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Sittable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Sittable.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class Sittable
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class Sittable : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/SpawnEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/SpawnEntity.kt
@@ -1,14 +1,18 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class SpawnEntity {
+class SpawnEntity : MonsteraRawFile() {
     @SerializedName("entities")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var entitiesData: Entities? = null
         @MonsteraBuildSetter set
 
@@ -29,7 +33,7 @@ class SpawnEntity {
         entitiesData = (entitiesData ?: Entities()).apply(value)
     }
 
-    class Entities {
+    class Entities : MonsteraRawFile() {
         @SerializedName("min_wait_time")
         @Expose
         var minWaitTime: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/SpellEffects.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/SpellEffects.kt
@@ -1,13 +1,17 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class SpellEffects {
+class SpellEffects : MonsteraRawFile() {
     @SerializedName("add_effects")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var addEffectsData: MutableList<AddEffects>? = null
         @MonsteraBuildSetter set
 
@@ -33,25 +37,21 @@ class SpellEffects {
     var removeEffects: MutableList<String>? = null
         
 
-    class AddEffects {
+    class AddEffects : MonsteraRawFile() {
         @SerializedName("effect")
         @Expose
         var effect: String? = null
             
-
         @SerializedName("duration")
         @Expose
         var duration: Number? = null
             
-
         @SerializedName("visible")
         @Expose
         var visible: Boolean? = null
             
-
         @SerializedName("display_on_screen_animation")
         @Expose
         var displayOnScreenAnimation: Boolean? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Strength.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Strength.kt
@@ -2,16 +2,14 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Strength {
+class Strength : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null
         
-
     @SerializedName("max")
     @Expose
     var max: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/SuspectTracking.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/SuspectTracking.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class SuspectTracking
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class SuspectTracking : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Tameable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Tameable.kt
@@ -1,28 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Tameable {
+class Tameable : MonsteraRawFile() {
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
         
-
     @SerializedName("tame_items")
     @Expose
     var tameItemsData: MutableList<String>? = null
         
-
     fun tameItems(vararg value: String) {
         tameItemsData = (tameItemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
 
     @SerializedName("tame_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var tameEventData: TameEvent? = null
         @MonsteraBuildSetter set
 
@@ -41,15 +43,13 @@ class Tameable {
         tameEventData = (tameEventData ?: TameEvent()).apply(value)
     }
 
-    class TameEvent {
+    class TameEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Tamemount.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Tamemount.kt
@@ -1,34 +1,35 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Tamemount {
+class Tamemount : MonsteraRawFile() {
     @SerializedName("min_temper")
     @Expose
     var minTemper: Number? = null
         
-
     @SerializedName("max_temper")
     @Expose
     var maxTemper: Number? = null
         
-
     @SerializedName("feed_text")
     @Expose
     var feedText: String? = null
         
-
     @SerializedName("ride_text")
     @Expose
     var rideText: String? = null
         
-
     @SerializedName("feed_items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var feedItemsData: MutableList<FeedItems>? = null
         @MonsteraBuildSetter set
 
@@ -49,6 +50,7 @@ class Tamemount {
 
     @SerializedName("auto_reject_items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var autoRejectItemsData: MutableList<AutoRejectItems>? = null
         @MonsteraBuildSetter set
 
@@ -68,6 +70,7 @@ class Tamemount {
 
     @SerializedName("tame_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var tameEventData: TameEvent? = null
         @MonsteraBuildSetter set
 
@@ -86,34 +89,29 @@ class Tamemount {
         tameEventData = (tameEventData ?: TameEvent()).apply(value)
     }
 
-    class FeedItems {
+    class FeedItems : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
             
-
         @SerializedName("temper_mod")
         @Expose
         var temperMod: Number? = null
-            
     }
 
-    class AutoRejectItems {
+    class AutoRejectItems : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
-            
     }
 
-    class TameEvent {
+    class TameEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TargetNearbySensor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TargetNearbySensor.kt
@@ -1,29 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class TargetNearbySensor {
+class TargetNearbySensor : MonsteraRawFile() {
     @SerializedName("inside_range")
     @Expose
     var insideRange: Number? = null
         
-
     @SerializedName("outside_range")
     @Expose
     var outsideRange: Number? = null
         
-
     @SerializedName("must_see")
     @Expose
     var mustSee: Boolean? = null
         
-
     @SerializedName("on_inside_range")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onInsideRangeData: OnInsideRange? = null
         @MonsteraBuildSetter set
 
@@ -44,6 +45,7 @@ class TargetNearbySensor {
 
     @SerializedName("on_outside_range")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onOutsideRangeData: OnOutsideRange? = null
         @MonsteraBuildSetter set
 
@@ -64,6 +66,7 @@ class TargetNearbySensor {
 
     @SerializedName("on_vision_lost_inside_range")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var onVisionLostInsideRangeData: OnVisionLostInsideRange? = null
         @MonsteraBuildSetter set
 
@@ -82,39 +85,33 @@ class TargetNearbySensor {
         onVisionLostInsideRangeData = (onVisionLostInsideRangeData ?: OnVisionLostInsideRange()).apply(value)
     }
 
-    class OnInsideRange {
+    class OnInsideRange : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnOutsideRange {
+    class OnOutsideRange : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 
-    class OnVisionLostInsideRange {
+    class OnVisionLostInsideRange : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Teleport.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Teleport.kt
@@ -2,24 +2,21 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class Teleport {
+class Teleport : MonsteraRawFile() {
     @SerializedName("random_teleports")
     @Expose
     var randomTeleports: Boolean? = null
         
-
     @SerializedName("max_random_teleport_time")
     @Expose
     var maxRandomTeleportTime: Number? = null
         
-
     @SerializedName("random_teleport_cube")
     @Expose
     var randomTeleportCubeData: MutableList<Number>? = null
         
-
     fun randomTeleportCube(vararg value: Number) {
         randomTeleportCubeData = (randomTeleportCubeData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
@@ -28,14 +25,11 @@ class Teleport {
     @Expose
     var targetDistance: Number? = null
         
-
     @SerializedName("target_teleport_chance")
     @Expose
     var targetTeleportChance: Number? = null
         
-
     @SerializedName("light_teleport_chance")
     @Expose
     var lightTeleportChance: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Timer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Timer.kt
@@ -1,24 +1,27 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Timer {
+class Timer : MonsteraRawFile() {
     @SerializedName("looping")
     @Expose
     var looping: Boolean? = null
-        
 
     @SerializedName("time")
     @Expose
     var time: Number? = null
-        
 
     @SerializedName("time_down_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var timeDownEventData: TimeDownEvent? = null
         @MonsteraBuildSetter set
 
@@ -39,10 +42,11 @@ class Timer {
     @SerializedName("randomInterval")
     @Expose
     var randomInterval: Boolean? = null
-        
+
 
     @SerializedName("random_time_choices")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var randomTimeChoicesData: MutableList<RandomTimeChoices>? = null
         @MonsteraBuildSetter set
 
@@ -62,7 +66,7 @@ class Timer {
             (randomTimeChoicesData ?: mutableListOf()).also { it.add(RandomTimeChoices().apply(value)) }
     }
 
-    class TimeDownEvent {
+    class TimeDownEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
@@ -72,15 +76,13 @@ class Timer {
         var target: Subject? = null
     }
 
-    class RandomTimeChoices {
+    class RandomTimeChoices : MonsteraRawFile() {
         @SerializedName("weight")
         @Expose
         var weight: Number? = null
-            
 
         @SerializedName("value")
         @Expose
         var value: Number? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TradeResupply.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TradeResupply.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class TradeResupply
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class TradeResupply : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TradeTable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TradeTable.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class TradeTable {
+class TradeTable : MonsteraRawFile() {
     @SerializedName("display_name")
     @Expose
     var displayName: String? = null
         
-
     @SerializedName("table")
     @Expose
     var table: String? = null
         
-
     @SerializedName("convert_trades_economy")
     @Expose
     var convertTradesEconomy: Boolean? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Trail.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Trail.kt
@@ -3,15 +3,15 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-class Trail {
+class Trail : MonsteraRawFile() {
     @SerializedName("block_type")
     @Expose
     var blockType: String? = null
         
-
     @SerializedName("spawn_filter")
     @Expose
     var spawnFilterData: BehEntityFilter? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Transformation.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Transformation.kt
@@ -1,33 +1,33 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class Transformation {
+class Transformation : MonsteraRawFile() {
     @SerializedName("into")
     @Expose
     var into: String? = null
         
-
     @SerializedName("transformation_sound")
     @Expose
     var transformationSound: String? = null
         
-
     @SerializedName("keep_level")
     @Expose
     var keepLevel: Boolean? = null
         
-
     @SerializedName("drop_equipment")
     @Expose
     var dropEquipment: Boolean? = null
         
-
     @SerializedName("delay")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var delayData: Delay? = null
         @MonsteraBuildSetter set
 
@@ -49,18 +49,15 @@ class Transformation {
     @Expose
     var dropInventory: Boolean? = null
         
-
     @SerializedName("preserve_equipment")
     @Expose
     var preserveEquipment: Boolean? = null
         
-
     @SerializedName("begin_transform_sound")
     @Expose
     var beginTransformSound: String? = null
         
-
-    class Delay {
+    class Delay : MonsteraRawFile() {
         @SerializedName("value")
         @Expose
         var value: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Trust.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Trust.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class Trust
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class Trust : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Trusting.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/Trusting.kt
@@ -1,28 +1,30 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 import com.lop.devtools.monstera.files.beh.entitiy.data.Subject
 
-class Trusting {
+class Trusting : MonsteraRawFile() {
     @SerializedName("probability")
     @Expose
     var probability: Number? = null
         
-
     @SerializedName("trust_items")
     @Expose
     var trustItemsData: MutableList<String>? = null
         
-
     fun trustItems(vararg value: String) {
         trustItemsData = (trustItemsData ?: mutableListOf()).also { it.addAll(value.toList()) }
     }
 
     @SerializedName("trust_event")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var trustEventData: TrustEvent? = null
         @MonsteraBuildSetter set
 
@@ -41,15 +43,13 @@ class Trusting {
         trustEventData = (trustEventData ?: TrustEvent()).apply(value)
     }
 
-    class TrustEvent {
+    class TrustEvent : MonsteraRawFile() {
         @SerializedName("event")
         @Expose
         var event: String? = null
             
-
         @SerializedName("target")
         @Expose
         var target: Subject? = null
-            
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TypeFamily.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/TypeFamily.kt
@@ -2,17 +2,21 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.entitiy.components.Components
 
-class TypeFamily {
+class TypeFamily : MonsteraRawFile() {
     @SerializedName("family")
     @Expose
     var familyData: MutableList<String>? = null
-        
 
     @Components.VanillaComponentMarker
     fun family(vararg value: String) {
-        familyData = (familyData ?: mutableListOf()).also { it.addAll(value.toList()) }
+        family(value.toList())
+    }
+
+    @Components.VanillaComponentMarker
+    fun family(value: List<String>) {
+        familyData = (familyData ?: mutableListOf()).also { it.addAll(value) }
     }
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/VariableMaxAutoStep.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/VariableMaxAutoStep.kt
@@ -2,21 +2,18 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class VariableMaxAutoStep {
+class VariableMaxAutoStep : MonsteraRawFile() {
     @SerializedName("base_value")
     @Expose
     var baseValue: Number? = null
         
-
     @SerializedName("controlled_value")
     @Expose
     var controlledValue: Number? = null
         
-
     @SerializedName("jump_prevented_value")
     @Expose
     var jumpPreventedValue: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/VibrationDamper.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/VibrationDamper.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class VibrationDamper
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class VibrationDamper : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/VibrationListener.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/VibrationListener.kt
@@ -1,3 +1,5 @@
 package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
-class VibrationListener
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class VibrationListener : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/WaterMovement.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/components/scraped/WaterMovement.kt
@@ -2,11 +2,10 @@ package com.lop.devtools.monstera.files.beh.entitiy.components.scraped
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
-import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class WaterMovement {
+class WaterMovement : MonsteraRawFile() {
     @SerializedName("drag_factor")
     @Expose
     var dragFactor: Number? = null
-        
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/description/BehEntityDescScripts.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/description/BehEntityDescScripts.kt
@@ -5,8 +5,9 @@ import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.addon.molang.Query
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEntityDescScripts {
+class BehEntityDescScripts : MonsteraRawFile() {
     @SerializedName("animate")
     @Expose
     var animateData: MutableList<Any>? = null
@@ -25,7 +26,7 @@ class BehEntityDescScripts {
 
     @OptIn(MonsteraBuildSetter::class)
     fun animate(animation: String, query: Molang = Query.True) {
-        animateData = if(query == Query.True)
+        animateData = if (query == Query.True)
             (animateData ?: mutableListOf()).also { it.add(animation) }
         else
             (animateData ?: mutableListOf()).also { it.add(mutableMapOf(animation to query.data)) }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/description/BehEntityDescription.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/description/BehEntityDescription.kt
@@ -1,15 +1,17 @@
 package com.lop.devtools.monstera.files.beh.entitiy.description
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.DebugMarker
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.properties.EntityProperties
 import com.lop.devtools.monstera.files.properties.types.GenericProperty
 import com.lop.devtools.monstera.getMonsteraLogger
 
-class BehEntityDescription: MonsteraRawFile() {
+open class BehEntityDescription: MonsteraRawFile() {
     @SerializedName("identifier")
     @Expose
     var identifier: String? = null
@@ -32,6 +34,7 @@ class BehEntityDescription: MonsteraRawFile() {
 
     @SerializedName("scripts")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var scriptsData: BehEntityDescScripts? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/events/BehEntityAddRemove.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/events/BehEntityAddRemove.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.entitiy.events
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class BehEntityAddRemove {
+class BehEntityAddRemove : MonsteraRawFile() {
     @SerializedName("component_groups")
     @Expose
     var componentGroups: MutableList<String>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/events/BehEntityEvent.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/entitiy/events/BehEntityEvent.kt
@@ -7,11 +7,12 @@ import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.DebugMarker
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.molang.Molang
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.entitiy.data.BehEntityFilter
 
-open class BehEntityEvent {
+open class BehEntityEvent : MonsteraRawFile() {
     open class ContainsFilter : BehEntityEvent() {
         @SerializedName("filters")
         @Expose
@@ -32,21 +33,25 @@ open class BehEntityEvent {
 
     @SerializedName("add")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var addGroupsData: BehEntityAddRemove? = null
         @MonsteraBuildSetter set
 
     @SerializedName("remove")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var removeGroupsData: BehEntityAddRemove? = null
         @MonsteraBuildSetter set
 
     @SerializedName("sequence")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var sequenceData: MutableList<ContainsFilter>? = null
         @MonsteraBuildSetter set
 
     @SerializedName("randomize")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var randomizeData: MutableList<ContainsWeight>? = null
         @MonsteraBuildSetter set
 
@@ -156,11 +161,11 @@ open class BehEntityEvent {
         groups.addAll(addGroupsData?.componentGroups ?: listOf())
         groups.addAll(sequenceData?.flatMap { it.getAddedGroups() } ?: listOf())
         groups.addAll(randomizeData?.flatMap { it.getAddedGroups() } ?: listOf())
-        
+
         return groups
     }
 
-    class QueueCommand: MonsteraRawFile()  {
+    class QueueCommand : MonsteraRawFile() {
         @SerializedName("command")
         @Expose
         var command: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItem.kt
@@ -11,24 +11,21 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
 
 class BehItem : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behItems ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for item file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for item file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for item file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for item file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behItem ?: "1.50.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItem.kt
@@ -145,6 +145,7 @@ class BehItem : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("menu_category")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var menuCategoryData: CategoryData? = null
             @MonsteraBuildSetter set
 
@@ -155,7 +156,7 @@ class BehItem : MonsteraBuildableFile, MonsteraRawFile() {
                 field = value
             }
 
-        class CategoryData {
+        class CategoryData : MonsteraRawFile() {
             @SerializedName("category")
             @Expose
             var category: Category? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItemComponents.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/BehItemComponents.kt
@@ -1,15 +1,18 @@
 package com.lop.devtools.monstera.files.beh.item
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.item.Item
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.item.comp.*
 
 class BehItemComponents : MonsteraRawFile() {
     @SerializedName("minecraft:icon")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var itemIconData: ItemIcon? = null
         @MonsteraBuildSetter set
 
@@ -25,6 +28,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:allow_off_hand")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var allowOffHandData: ItemAllowOffHand? = null
         @MonsteraBuildSetter set
 
@@ -35,6 +39,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:armor")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var armorData: ItemArmor? = null
         @MonsteraBuildSetter set
 
@@ -45,6 +50,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:block_placer")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var blockPlaceData: ItemBlockPlacer? = null
         @MonsteraBuildSetter set
 
@@ -66,6 +72,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:can_destroy_in_creative")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var canDestroyInCreativeData: ItemCanDestroyInCreative? = null
         @MonsteraBuildSetter set
 
@@ -79,6 +86,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:cooldown")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var cooldownData: ItemCooldown? = null
         @MonsteraBuildSetter set
 
@@ -100,6 +108,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:creative_category")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var creativeCategoryData: ItemCreativeCategory? = null
         @MonsteraBuildSetter set
 
@@ -122,6 +131,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:damage")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var damageData: ItemDamage? = null
         @MonsteraBuildSetter set
 
@@ -135,6 +145,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:digger")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var diggerData: ItemDigger? = null
         @MonsteraBuildSetter set
 
@@ -159,6 +170,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:display_name")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var displayNameData: ItemDisplayName? = null
         @MonsteraBuildSetter set
 
@@ -190,6 +202,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:durability")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var durabilityData: ItemDurability? = null
         @MonsteraBuildSetter set
 
@@ -210,6 +223,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:enchantable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var enchantableData: ItemEnchantable? = null
         @MonsteraBuildSetter set
 
@@ -230,6 +244,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:entity_placer")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var entityPlacerData: ItemEntityPlacer? = null
         @MonsteraBuildSetter set
 
@@ -251,6 +266,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:food")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var foodData: ItemFood? = null
         @MonsteraBuildSetter set
 
@@ -282,6 +298,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:fuel")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var fuelData: ItemFuel? = null
         @MonsteraBuildSetter set
 
@@ -308,6 +325,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:hand_equipped")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var handEquippedData: ItemHandEquipped? = null
         @MonsteraBuildSetter set
 
@@ -336,6 +354,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:liquid_clipped")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var liquidClippedData: ItemLiquidClipped? = null
         @MonsteraBuildSetter set
 
@@ -350,6 +369,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:max_stack_size")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var maxStackSizeData: ItemMaxStackSize? = null
         @MonsteraBuildSetter set
 
@@ -363,6 +383,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:projectile")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var projectileData: ItemProjectile? = null
         @MonsteraBuildSetter set
 
@@ -385,6 +406,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:record")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var recordData: ItemRecord? = null
         @MonsteraBuildSetter set
 
@@ -409,6 +431,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:repairable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var repairableData: ItemRepairable? = null
         @MonsteraBuildSetter set
 
@@ -431,6 +454,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:shooter")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var shooterData: ItemShooter? = null
         @MonsteraBuildSetter set
 
@@ -461,6 +485,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:should_despawn")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var shouldDespawnData: ItemShouldDespawn? = null
         @MonsteraBuildSetter set
 
@@ -474,6 +499,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:stacked_by_data")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var stackedByDataData: ItemStackedByData? = null
         @MonsteraBuildSetter set
 
@@ -488,6 +514,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:throwable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var throwableData: ItemThrowable? = null
         @MonsteraBuildSetter set
 
@@ -508,6 +535,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:use_modifiers")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var useModifiersData: ItemUseModifiers? = null
         @MonsteraBuildSetter set
 
@@ -528,6 +556,7 @@ class BehItemComponents : MonsteraRawFile() {
 
     @SerializedName("minecraft:wearable")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var wearableData: ItemWearable? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemAllowOffHand.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemAllowOffHand.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemAllowOffHand {
+class ItemAllowOffHand : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemArmor.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemArmor.kt
@@ -1,8 +1,9 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-open class ItemArmor {
+open class ItemArmor : MonsteraRawFile() {
     @Expose
     var protection: Number? = null
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemBlockPlacer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemBlockPlacer.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemBlockPlacer {
+class ItemBlockPlacer : MonsteraRawFile() {
     @SerializedName("block")
     @Expose
     var block: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemCanDestroyInCreative.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemCanDestroyInCreative.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemCanDestroyInCreative {
+class ItemCanDestroyInCreative : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemCooldown.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemCooldown.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemCooldown {
+class ItemCooldown : MonsteraRawFile() {
     @SerializedName("category")
     @Expose
     var category: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemCreativeCategory.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemCreativeCategory.kt
@@ -1,8 +1,9 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-open class ItemCreativeCategory {
+open class ItemCreativeCategory : MonsteraRawFile() {
     @Expose
     var parent: String? = null  
 }

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDamage.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDamage.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemDamage {
+class ItemDamage : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDigger.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDigger.kt
@@ -1,17 +1,20 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
-import com.lop.devtools.monstera.files.beh.entitiy.components.scraped.Strength
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemDigger {
+class ItemDigger : MonsteraRawFile() {
     @SerializedName("use_efficiency")
     @Expose
     var useEfficiency: Boolean? = null
 
     @SerializedName("destroy_speeds")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var destroySpeedsData: MutableList<DestroySpeed>? = null
         @MonsteraBuildSetter set
 
@@ -26,7 +29,7 @@ class ItemDigger {
     }
 
 
-    class DestroySpeed {
+    class DestroySpeed : MonsteraRawFile() {
         @SerializedName("speed")
         @Expose
         var speed: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDisplayName.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDisplayName.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemDisplayName {
+class ItemDisplayName : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDurability.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemDurability.kt
@@ -1,12 +1,16 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 
-class ItemDurability {
+class ItemDurability : MonsteraRawFile() {
     @SerializedName("damage_chance")
     @Expose
+    @JsonAdapter(MonsteraRawFileTypeAdapter::class)
     var damageChanceData: DamageChance? = null
         @MonsteraBuildSetter set
 
@@ -22,7 +26,7 @@ class ItemDurability {
     @Expose
     var maxDurability: Number? = null
 
-    class DamageChance {
+    class DamageChance : MonsteraRawFile() {
         @SerializedName("min")
         @Expose
         var min: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemEnchantable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemEnchantable.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemEnchantable {
+class ItemEnchantable : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemEntityPlacer.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemEntityPlacer.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemEntityPlacer {
+class ItemEntityPlacer : MonsteraRawFile() {
     @SerializedName("entity")
     @Expose
     var entity: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemFood.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemFood.kt
@@ -1,10 +1,13 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemFood {
+class ItemFood : MonsteraRawFile() {
     @SerializedName("can_always_eat")
     @Expose
     var canAlwaysEat: Boolean? = null
@@ -23,6 +26,7 @@ class ItemFood {
 
     @SerializedName("effects")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var effects: MutableList<Effect>? = null
         @MonsteraBuildSetter set
 
@@ -34,7 +38,7 @@ class ItemFood {
         effects = (effects ?: mutableListOf()).apply { add(Effect().apply(data)) }
     }
 
-    class Effect {
+    class Effect : MonsteraRawFile() {
         @SerializedName("name")
         @Expose
         var name: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemFuel.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemFuel.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemFuel {
+class ItemFuel : MonsteraRawFile() {
     @SerializedName("duration")
     @Expose
     var duration: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemHandEquipped.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemHandEquipped.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemHandEquipped {
+class ItemHandEquipped : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemIcon.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemIcon.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemIcon {
+class ItemIcon : MonsteraRawFile() {
     @SerializedName("texture")
     @Expose
     var texture: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemLiquidClipped.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemLiquidClipped.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemLiquidClipped {
+class ItemLiquidClipped : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemMaxStackSize.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemMaxStackSize.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemMaxStackSize {
+class ItemMaxStackSize : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Int? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemProjectile.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemProjectile.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemProjectile {
+class ItemProjectile : MonsteraRawFile() {
     @SerializedName("minimum_critical_power")
     @Expose
     var minimumCriticalPower: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemRecord.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemRecord.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemRecord {
+class ItemRecord : MonsteraRawFile() {
     @SerializedName("comparator_signal")
     @Expose
     var comparatorSignal: Int? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemRepairable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemRepairable.kt
@@ -3,17 +3,21 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.molang.Molang
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-open class ItemRepairable {
+open class ItemRepairable : MonsteraRawFile() {
     @SerializedName("on_repaired")
     @Expose
     var onRepaired: String? = null
 
     @SerializedName("repair_items")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var repairItems: MutableList<RepairItem>? = null
         @MonsteraBuildSetter set
 
@@ -22,7 +26,7 @@ open class ItemRepairable {
         repairItems = (repairItems ?: mutableListOf()).apply { add(RepairItem().apply(data)) }
     }
 
-    open class RepairItem {
+    open class RepairItem : MonsteraRawFile() {
         @SerializedName("items")
         @Expose
         var items: MutableList<String>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemShooter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemShooter.kt
@@ -1,9 +1,12 @@
 package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemShooter {
+class ItemShooter : MonsteraRawFile() {
     @SerializedName("max_draw_duration")
     @Expose
     var maxDrawDuration: Number? = null
@@ -18,6 +21,7 @@ class ItemShooter {
 
     @SerializedName("ammunition")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var ammunitionData: MutableList<Ammunition>? = null
 
     /**
@@ -36,7 +40,7 @@ class ItemShooter {
         ammunitionData = (ammunitionData ?: mutableListOf()).apply { add(Ammunition().apply(data)) }
     }
 
-    class Ammunition {
+    class Ammunition : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemShouldDespawn.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemShouldDespawn.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemShouldDespawn {
+class ItemShouldDespawn : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemStackedByData.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemStackedByData.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemStackedByData {
+class ItemStackedByData : MonsteraRawFile() {
     @SerializedName("value")
     @Expose
     var value: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemThrowable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemThrowable.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemThrowable {
+class ItemThrowable : MonsteraRawFile() {
     @SerializedName("do_swing_animation")
     @Expose
     var doSwingAnimation: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemUseModifiers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemUseModifiers.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemUseModifiers {
+class ItemUseModifiers : MonsteraRawFile() {
     @SerializedName("use_duration")
     @Expose
     var useDuration: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemWearable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/item/comp/ItemWearable.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.item.comp
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class ItemWearable {
+class ItemWearable : MonsteraRawFile() {
     @SerializedName("dispensable")
     @Expose
     var dispensable: Boolean? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/recipes/BehRecipe.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/recipes/BehRecipe.kt
@@ -8,10 +8,7 @@ import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
-import com.lop.devtools.monstera.files.MonsteraBuilder
-import com.lop.devtools.monstera.files.MonsteraRawFile
-import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
-import com.lop.devtools.monstera.files.sanetiseFilename
+import com.lop.devtools.monstera.files.*
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -235,6 +232,7 @@ class BehRecipe {
 
     @SerializedName("result")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var resultData: MutableList<ItemInfo>? = null
         @MonsteraBuildSetter set
 
@@ -261,6 +259,7 @@ class BehRecipe {
 
     @SerializedName("ingredients")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var ingredientsData: MutableList<ItemInfo>? = null
         @MonsteraBuildSetter set
 
@@ -284,7 +283,7 @@ class BehRecipe {
         ingredientsData = (ingredientsData ?: mutableListOf()).apply { add(ItemInfo().apply(data)) }
     }
 
-    open class ItemInfo {
+    open class ItemInfo : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/recipes/BehRecipe.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/recipes/BehRecipe.kt
@@ -11,6 +11,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -19,18 +20,14 @@ class BehRecipeShaped : MonsteraBuildableFile, MonsteraRawFile() {
     var data = BehRecipe()
 
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behRecipe ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for crafting recipe file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for crafting recipe file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for crafting recipe file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for crafting recipe file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             BehRecipe.FileHeaderShaped(
                 version ?: Addon.active?.config?.formatVersions?.behRecipe ?: "1.17.41",
                 data

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/BehSpawnRules.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/BehSpawnRules.kt
@@ -12,24 +12,21 @@ import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.beh.spawnrules.conditions.*
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
 
 class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behBlocks ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for spawn rule file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for spawn rule file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for spawn rule file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for spawn rule file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.behSpawnRules ?: "1.8.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/BehSpawnRules.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/BehSpawnRules.kt
@@ -8,11 +8,8 @@ import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
-import com.lop.devtools.monstera.files.MonsteraBuilder
-import com.lop.devtools.monstera.files.MonsteraRawFile
-import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.*
 import com.lop.devtools.monstera.files.beh.spawnrules.conditions.*
-import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -77,6 +74,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("conditions")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var conditionsData: MutableList<Condition>? = null
         @MonsteraBuildSetter set
 
@@ -108,9 +106,10 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
         conditionsData = (conditionsData ?: mutableListOf()).apply { add(Condition().apply(data)) }
     }
 
-    open class Condition {
+    open class Condition : MonsteraRawFile() {
         @SerializedName("minecraft:weight")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var weightData: SpawnWeight? = null
             @MonsteraBuildSetter set
 
@@ -121,6 +120,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:density_limit")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var densityLimitData: SpawnDensityLimit? = null
             @MonsteraBuildSetter set
 
@@ -147,6 +147,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:spawns_above_block_filter")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var spawnsAboveBlockFilterData: SpawnAboveBlockFilter? = null
             @MonsteraBuildSetter set
 
@@ -168,6 +169,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:herd")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var herdData: SpawnHerd? = null
             @MonsteraBuildSetter set
 
@@ -188,6 +190,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:permute_type")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var permuteTypeData: MutableList<SpawnPermuteType>? = null
             @MonsteraBuildSetter set
 
@@ -210,6 +213,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:brightness_filter")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var brightnessFilterData: SpawnBrightnessFilter? = null
             @MonsteraBuildSetter set
 
@@ -229,6 +233,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:height_filter")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var heightFilterData: SpawnHeightFilter? = null
             @MonsteraBuildSetter set
 
@@ -247,6 +252,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:spawns_on_surface")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var spawnsOnSurfaceData: SpawnsOnSurface? = null
             @MonsteraBuildSetter set
 
@@ -257,6 +263,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:spawns_underground")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var spawnsUndergroundData: SpawnsUnderground? = null
             @MonsteraBuildSetter set
 
@@ -267,6 +274,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:spawns_underwater")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var spawnsUnderwaterData: SpawnsUnderwater? = null
             @MonsteraBuildSetter set
 
@@ -277,6 +285,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:disallow_spawns_in_bubble")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var disallowSpawnsInBubbleData: SpawnDisallowSpawnsInBubble? = null
             @MonsteraBuildSetter set
 
@@ -287,6 +296,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:spawns_lava")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var spawnsLavaData: SpawnsLava? = null
             @MonsteraBuildSetter set
 
@@ -297,6 +307,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:biome_filter")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var biomeFilterData: SpawnBiomeFilter? = null
             @MonsteraBuildSetter set
 
@@ -317,6 +328,7 @@ class BehSpawnRules : MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("minecraft:difficulty_filter")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var difficultyFilterData: SpawnDifficultyFilter? = null
             @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnAboveBlockFilter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnAboveBlockFilter.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnAboveBlockFilter {
+class SpawnAboveBlockFilter : MonsteraRawFile() {
     @SerializedName("blocks")
     @Expose
     var blocks: MutableList<String>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnBiomeFilter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnBiomeFilter.kt
@@ -3,8 +3,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnBiomeFilter {
+class SpawnBiomeFilter : MonsteraRawFile() {
     private val filterEntries = mutableListOf<SpawnBiomeFilter>()
 
     @OptIn(MonsteraBuildSetter::class)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnBrightnessFilter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnBrightnessFilter.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnBrightnessFilter {
+class SpawnBrightnessFilter : MonsteraRawFile() {
     @SerializedName("min")
     @Expose
     var min: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnDensityLimit.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnDensityLimit.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnDensityLimit {
+class SpawnDensityLimit : MonsteraRawFile() {
     @SerializedName("surface")
     @Expose
     var surface: Int? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnDifficultyFilter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnDifficultyFilter.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnDifficultyFilter {
+class SpawnDifficultyFilter : MonsteraRawFile() {
     @SerializedName("min")
     @Expose
     var min: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnDisallowSpawnsInBubble.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnDisallowSpawnsInBubble.kt
@@ -1,5 +1,5 @@
 package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
-class SpawnDisallowSpawnsInBubble
-{
-}
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class SpawnDisallowSpawnsInBubble : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnHeightFilter.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnHeightFilter.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnHeightFilter {
+class SpawnHeightFilter : MonsteraRawFile() {
     @SerializedName("min")
     @Expose
     var min: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnHerd.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnHerd.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnHerd {
+class SpawnHerd : MonsteraRawFile() {
     @SerializedName("min_size")
     @Expose
     var minSize: Int? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnPermuteType.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnPermuteType.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnPermuteType {
+class SpawnPermuteType : MonsteraRawFile() {
     @SerializedName("weight")
     @Expose
     var weight: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnWeight.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnWeight.kt
@@ -2,8 +2,9 @@ package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
 import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
+import com.lop.devtools.monstera.files.MonsteraRawFile
 
-class SpawnWeight {
+class SpawnWeight : MonsteraRawFile() {
     @SerializedName("default")
     @Expose
     var default: Number? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsLava.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsLava.kt
@@ -1,4 +1,5 @@
 package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
-class SpawnsLava {
-}
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class SpawnsLava : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsOnSurface.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsOnSurface.kt
@@ -1,4 +1,5 @@
 package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
-class SpawnsOnSurface {
-}
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class SpawnsOnSurface : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsUnderground.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsUnderground.kt
@@ -1,4 +1,5 @@
 package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
-class SpawnsUnderground {
-}
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class SpawnsUnderground : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsUnderwater.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/spawnrules/conditions/SpawnsUnderwater.kt
@@ -1,4 +1,5 @@
 package com.lop.devtools.monstera.files.beh.spawnrules.conditions
 
-class SpawnsUnderwater {
-}
+import com.lop.devtools.monstera.files.MonsteraRawFile
+
+class SpawnsUnderwater : MonsteraRawFile()

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
@@ -20,11 +20,12 @@ class BehLootTables: MonsteraRawFile() {
             val sub = path.toString().split("loot_tables").last().replace("\\", "/")
             return "loot_tables$sub"
         }
+        private val logger = getMonsteraLogger(this::class.simpleName ?: "BehLootTables")
     }
     class Block(val data: BehLootTables) : MonsteraBuildableFile {
         override fun build(filename: String, path: Path?, version: String?): Result<Path> {
             val selPath = path ?: Addon.active?.config?.paths?.lootTableBlock ?: run {
-                getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!")
+                logger.error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!")
                 return Result.failure(Error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!"))
             }
             val target = MonsteraBuilder.buildTo(
@@ -43,7 +44,7 @@ class BehLootTables: MonsteraRawFile() {
                 .replace("-", "_")
                 .replace(" ", "_")
             val selPath = path ?: Addon.active?.config?.paths?.lootTableEntity ?: run {
-                getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for entity loot file '$sanFile' as no addon was initialized!")
+                logger.error("Could not Resolve a path for entity loot file '$sanFile' as no addon was initialized!")
                 return Result.failure(Error("Could not Resolve a path for entity loot file '$sanFile' as no addon was initialized!"))
             }
 
@@ -60,7 +61,6 @@ class BehLootTables: MonsteraRawFile() {
      * returns true if no pool is defined
      */
     fun isEmpty() = poolsData.isNullOrEmpty()
-
 
     @SerializedName("pools")
     @Expose
@@ -154,6 +154,12 @@ class BehLootTables: MonsteraRawFile() {
         @Expose
         var functionData: MutableList<Any>? = null
             @MonsteraBuildSetter set
+
+        /**
+         * in older monstera version the identifier field was known as "name"
+         */
+        @Deprecated("", ReplaceWith("identifier"))
+        var name: String? = null
 
         /**
          * ```

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
@@ -10,6 +10,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.shared.BehTableFun
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
@@ -22,17 +23,13 @@ class BehLootTables: MonsteraRawFile() {
     }
     class Block(val data: BehLootTables) : MonsteraBuildableFile {
         override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-            val sanFile = filename
-                .removeSuffix(".json")
-                .replace("-", "_")
-                .replace(" ", "_")
             val selPath = path ?: Addon.active?.config?.paths?.lootTableBlock ?: run {
-                getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block loot file '$sanFile' as no addon was initialized!")
-                return Result.failure(Error("Could not Resolve a path for block loot file '$sanFile' as no addon was initialized!"))
+                getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!")
+                return Result.failure(Error("Could not Resolve a path for block loot file '$filename' as no addon was initialized!"))
             }
             val target = MonsteraBuilder.buildTo(
                 selPath,
-                "$sanFile.json",
+                sanetiseFilename(filename, "json"),
                 data
             )
             return Result.success(target)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/loot/BehLootTables.kt
@@ -3,11 +3,13 @@
 package com.lop.devtools.monstera.files.beh.tables.loot
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.shared.BehTableFun
 import com.lop.devtools.monstera.files.sanetiseFilename
@@ -64,6 +66,7 @@ class BehLootTables: MonsteraRawFile() {
 
     @SerializedName("pools")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var poolsData: MutableList<Pool>? = null
         @MonsteraBuildSetter set
 
@@ -85,7 +88,7 @@ class BehLootTables: MonsteraRawFile() {
         poolsData = (poolsData ?: mutableListOf()).apply { add(Pool().apply(data)) }
     }
 
-    open class Pool {
+    open class Pool : MonsteraRawFile() {
         @SerializedName("rolls")
         @Expose
         var rollsData: Any? = null
@@ -106,6 +109,7 @@ class BehLootTables: MonsteraRawFile() {
 
         @SerializedName("entries")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var entryData: MutableList<Entry>? = null
             @MonsteraBuildSetter set
 
@@ -137,7 +141,7 @@ class BehLootTables: MonsteraRawFile() {
         var max: Int? = null
     }
 
-    open class Entry {
+    open class Entry : MonsteraRawFile() {
         @SerializedName("type")
         @Expose
         var type: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/trading/BehEconomyTrades.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/trading/BehEconomyTrades.kt
@@ -10,6 +10,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.shared.BehTableFun
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -23,18 +24,14 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
     }
 
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.behTrading ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for tade table file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for tade table file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for tade table file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for tade table file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             this
         )
         return Result.success(target)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/trading/BehEconomyTrades.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/beh/tables/trading/BehEconomyTrades.kt
@@ -3,11 +3,13 @@
 package com.lop.devtools.monstera.files.beh.tables.trading
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.beh.tables.shared.BehTableFun
 import com.lop.devtools.monstera.files.sanetiseFilename
@@ -39,6 +41,7 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("tiers")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var tierData: MutableList<Tier>? = null
         @MonsteraBuildSetter set
 
@@ -61,9 +64,10 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
         tierData = (tierData ?: mutableListOf()).apply { add(Tier().apply(data)) }
     }
 
-    open class Tier {
+    open class Tier : MonsteraRawFile() {
         @SerializedName("groups")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var groupsData: MutableList<Group>? = null
             @MonsteraBuildSetter set
 
@@ -92,6 +96,7 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("trades")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var tradesData: MutableList<Trade>? = null
             @MonsteraBuildSetter set
 
@@ -114,13 +119,14 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
         }
     }
 
-    open class Group {
+    open class Group : MonsteraRawFile() {
         @SerializedName("num_to_select")
         @Expose
         var numToSelect: Number? = null
 
         @SerializedName("trades")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var tradesData: MutableList<Trade>? = null
             @MonsteraBuildSetter set
 
@@ -143,9 +149,10 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
         }
     }
 
-    open class Trade {
+    open class Trade : MonsteraRawFile() {
         @SerializedName("wants")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var wantsData: MutableList<Want>? = null
             @MonsteraBuildSetter set
 
@@ -171,6 +178,7 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
 
         @SerializedName("gives")
         @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
         var givesData: MutableList<Give>? = null
             @MonsteraBuildSetter set
 
@@ -207,7 +215,7 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
         var rewardExp: Boolean? = null
     }
 
-    open class Want {
+    open class Want : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null
@@ -232,7 +240,7 @@ class BehEconomyTrades: MonsteraBuildableFile, MonsteraRawFile() {
         var priceMultiplier: Number? = null
     }
 
-    open class Give {
+    open class Give : MonsteraRawFile() {
         @SerializedName("item")
         @Expose
         var item: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
@@ -25,7 +25,7 @@ fun generateManifest(
     val enableScripting = scriptEntryFile.exists() && scriptEntryFile.isFile
 
     if (enableScripting && config.targetMcVersion[0] == 1 && config.targetMcVersion[1] < 20) {
-        logger.warn("Scripting is only available in version 1.20 or greater! Update your targetMcVersion!")
+        logger.warn("Scripting is only available in version 1.20 or higher! Update your targetMcVersion!")
     }
 
     //Manifest

--- a/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/manifest/manifestGenerator.kt
@@ -18,7 +18,7 @@ import java.util.*
 fun generateManifest(
     version: MutableList<Int> = arrayListOf(1, 0, 0),
     config: Config,
-    minEnginVersion: ArrayList<Int> = config.targetMcVersion,
+    minEnginVersion: MutableList<Int> = config.targetMcVersion,
     scriptEntryFile: File = File()
 ): Pair<UUID, UUID> {
     val logger = LoggerFactory.getLogger("Manifest")

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/attachables/ResAttachable.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/attachables/ResAttachable.kt
@@ -12,6 +12,7 @@ import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
 import java.nio.file.Path
@@ -20,18 +21,14 @@ class ResAttachable : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
         if(isEmtpy())
             return Result.failure(Error("File is empty!"))
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resAttachable ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for attachable file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for attachable file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for attachable file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for attachable file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.resAttachable ?: "1.10.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/blocks/TerrainTextures.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/blocks/TerrainTextures.kt
@@ -1,10 +1,12 @@
 package com.lop.devtools.monstera.files.res.blocks
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.*
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraMapFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 
 class TerrainTextures : InvokeBeforeEnd, MonsteraRawFile() {
@@ -26,6 +28,7 @@ class TerrainTextures : InvokeBeforeEnd, MonsteraRawFile() {
 
     @SerializedName("texture_data")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var textureData: MutableMap<String, Texture>? = null
         @MonsteraBuildSetter set
 
@@ -36,7 +39,7 @@ class TerrainTextures : InvokeBeforeEnd, MonsteraRawFile() {
         }
     }
 
-    open class Texture {
+    open class Texture : MonsteraRawFile() {
         @SerializedName("textures")
         @Expose
         var textures: String? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/entities/ResEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/entities/ResEntity.kt
@@ -10,10 +10,7 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.addon.molang.Molang
 import com.lop.devtools.monstera.addon.molang.Query
-import com.lop.devtools.monstera.files.MonsteraBuilder
-import com.lop.devtools.monstera.files.MonsteraRawFile
-import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
-import com.lop.devtools.monstera.files.getUniqueFileName
+import com.lop.devtools.monstera.files.*
 import com.lop.devtools.monstera.files.res.TextureIndex
 import com.lop.devtools.monstera.files.res.entities.comp.*
 import com.lop.devtools.monstera.files.res.materials.Material
@@ -24,18 +21,14 @@ import java.nio.file.Path
 
 class ResEntity: MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename
-            .removeSuffix(".json")
-            .replace("-", "_")
-            .replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resEntity ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for entity file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for entity file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for entity file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.resEntity ?: "1.10.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/items/ResItem.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/items/ResItem.kt
@@ -11,20 +11,20 @@ import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.files.res.ItemTextureIndex
 import com.lop.devtools.monstera.files.res.TextureIndex
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
 class ResItem : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename.removeSuffix(".json").replace("-", "_").replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resItem ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res item file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for res item file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res item file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for res item file '$filename' as no addon was initialized!"))
         }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             FileHeader(
                 version ?: Addon.active?.config?.formatVersions?.resItem ?: "1.10.0",
                 this

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderController.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderController.kt
@@ -7,11 +7,12 @@ import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.molang.Query
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import java.awt.Color
 
 @OptIn(MonsteraBuildSetter::class)
-open class ResRenderController {
+open class ResRenderController : MonsteraRawFile() {
     @SerializedName("textures")
     @Expose
     var texturesData: MutableList<String>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderControllers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderControllers.kt
@@ -7,22 +7,22 @@ import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
 import com.lop.devtools.monstera.files.MonsteraRawFile
+import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.nio.file.Path
 
 class ResRenderControllers : MonsteraBuildableFile, MonsteraRawFile() {
     override fun build(filename: String, path: Path?, version: String?): Result<Path> {
-        val sanFile = filename.removeSuffix(".json").replace("-", "_").replace(" ", "_")
         val selPath = path ?: Addon.active?.config?.paths?.resRenderControllers ?: run {
-            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res render controller file '$sanFile' as no addon was initialized!")
-            return Result.failure(Error("Could not Resolve a path for res render controller file '$sanFile' as no addon was initialized!"))
+            getMonsteraLogger(this.javaClass.name).error("Could not Resolve a path for res render controller file '$filename' as no addon was initialized!")
+            return Result.failure(Error("Could not Resolve a path for res render controller file '$filename' as no addon was initialized!"))
         }
         Addon.active?.config?.formatVersions?.resRendercontroller?.let { formatVersion = it }
         version?.let { formatVersion = it }
 
         val target = MonsteraBuilder.buildTo(
             selPath,
-            "$sanFile.json",
+            sanetiseFilename(filename, "json"),
             this
         )
         return Result.success(target)

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderControllers.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/rendercontrollers/ResRenderControllers.kt
@@ -1,11 +1,13 @@
 package com.lop.devtools.monstera.files.res.rendercontrollers
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraMapFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.sanetiseFilename
 import com.lop.devtools.monstera.getMonsteraLogger
@@ -34,6 +36,7 @@ class ResRenderControllers : MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("render_controllers")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var renderControllers: MutableMap<String, ResRenderController>? = null
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/sounds/ResSoundDef.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/sounds/ResSoundDef.kt
@@ -4,11 +4,12 @@ import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
+import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.getUniqueFileName
 import java.io.File
 
 @Suppress("unused")
-open class ResSoundDef {
+open class ResSoundDef : MonsteraRawFile() {
     @SerializedName("sounds")
     @Expose
     var soundsData: MutableList<Any>? = null

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/sounds/ResSoundDefs.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/sounds/ResSoundDefs.kt
@@ -1,11 +1,13 @@
 package com.lop.devtools.monstera.files.res.sounds
 
 import com.google.gson.annotations.Expose
+import com.google.gson.annotations.JsonAdapter
 import com.google.gson.annotations.SerializedName
 import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraListFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.getMonsteraLogger
 import java.lang.Error
@@ -39,6 +41,7 @@ class ResSoundDefs : MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("sound_definitions")
     @Expose
+    @JsonAdapter(MonsteraListFileTypeAdapter::class)
     var soundDefinitions: MutableMap<String, ResSoundDef> = mutableMapOf()
         @MonsteraBuildSetter set
 

--- a/src/main/kotlin/com/lop/devtools/monstera/files/res/sounds/Sounds.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/files/res/sounds/Sounds.kt
@@ -7,6 +7,7 @@ import com.lop.devtools.monstera.addon.Addon
 import com.lop.devtools.monstera.addon.api.MonsteraBuildSetter
 import com.lop.devtools.monstera.addon.api.MonsteraBuildableFile
 import com.lop.devtools.monstera.files.MonsteraBuilder
+import com.lop.devtools.monstera.files.MonsteraMapFileTypeAdapter
 import com.lop.devtools.monstera.files.MonsteraRawFile
 import com.lop.devtools.monstera.files.MonsteraRawFileTypeAdapter
 import com.lop.devtools.monstera.getMonsteraLogger
@@ -33,6 +34,7 @@ class Sounds : MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("block_sounds")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var blockSoundsData: MutableMap<String, SoundEvents>? = null
         @MonsteraBuildSetter set
 
@@ -44,22 +46,26 @@ class Sounds : MonsteraBuildableFile, MonsteraRawFile() {
 
     @SerializedName("individual_event_sounds")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var individualEventSoundData: MutableMap<String, SoundEvents>? = null
         @MonsteraBuildSetter set
 
     @SerializedName("interactive_sounds")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var interactiveSoundData: MutableMap<String, SoundEvents>? = null
         @MonsteraBuildSetter set
 
     class EntitySpecSound : MonsteraRawFile() {
         @SerializedName("entities")
         @Expose
+        @JsonAdapter(MonsteraMapFileTypeAdapter::class)
         var entitiesData: MutableMap<String, SoundEvents>? = null
             @MonsteraBuildSetter set
 
         @SerializedName("defaults")
         @Expose
+        @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var defaultsData: SoundEvents? = null
             @MonsteraBuildSetter set
     }
@@ -179,9 +185,10 @@ open class SpecSounds {
     }
 }
 
-open class SoundEvents {
+open class SoundEvents : MonsteraRawFile() {
     @SerializedName("events")
     @Expose
+    @JsonAdapter(MonsteraMapFileTypeAdapter::class)
     var eventsData: MutableMap<String, SoundEventSettings>? = null
         @MonsteraBuildSetter set
 
@@ -199,7 +206,7 @@ open class SoundEvents {
     }
 }
 
-open class SoundEventSettings {
+open class SoundEventSettings : MonsteraRawFile() {
     @SerializedName("volume")
     @Expose
     var volumeData: Any? = null

--- a/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
@@ -3,58 +3,62 @@ package com.lop.devtools.monstera
 import com.lop.devtools.monstera.addon.addon
 import com.lop.devtools.monstera.files.getResource
 import java.awt.Color
+import kotlin.test.Test
 
-fun main() {
-    val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
-        getMonsteraLogger("addon").error(it.message)
-        it.printStackTrace()
-        return
-    }
+class Integration {
+    @Test
+    fun intTest() {
+        val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
+                getMonsteraLogger("addon").error(it.message)
+                it.printStackTrace()
+                return
+            }
 
-    val conf2 = config("my_test")  {
-        namespace = "monstera"
-        projectShort = "te"
-    }
+            val conf2 = config("my_test")  {
+                namespace = "monstera"
+                projectShort = "te"
+            }
 
-    addon(
-       conf2
-    ) {
-        entity("my_test_entity", "My Test Entity") {
-            behaviour {
-                components {
-                    physics {  }
-                    pushable {  }
+            addon(
+            conf1
+            ) {
+                entity("my_test_entity", "My Test Entity") {
+                    behaviour {
+                        components {
+                            physics {  }
+                            pushable {  }
+                        }
+                        properties {
+                            enum("1rwong_start") {
+                                default("abc")
+                                values = mutableListOf("abc", "ab")
+                            }
+                            enum("missing_default") {
+                                values = mutableListOf("a")
+                            }
+                            enum("missing_values") {
+                                default("ab")
+                            }
+                        }
+
+                        craftingRecipe {
+
+                        }
+                    }
+                    resource {
+                        components {
+                            spawnEgg("Spawn $name") {
+                                eggByColor(Color.CYAN, Color.BLACK)
+                            }
+                        }
+                    }
                 }
-                properties {
-                    enum("1rwong_start") {
-                        default("abc")
-                        values = mutableListOf("abc", "ab")
-                    }
-                    enum("missing_default") {
-                        values = mutableListOf("a")
-                    }
-                    enum("missing_values") {
-                        default("ab")
-                    }
-                }
+                entity("aververyverlongnametahtisshurlytoolongthanks") {
 
-                craftingRecipe {
+                }
+                item("my_item", "My Item") {
 
                 }
             }
-            resource {
-                components {
-                    spawnEgg("Spawn $name") {
-                        eggByColor(Color.CYAN, Color.BLACK)
-                    }
-                }
-            }
-        }
-        entity("aververyverlongnametahtisshurlytoolongthanks") {
-
-        }
-        item("my_item", "My Item") {
-            
-        }
     }
 }

--- a/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
@@ -9,56 +9,56 @@ class Integration {
     @Test
     fun intTest() {
         val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
-                getMonsteraLogger("addon").error(it.message)
-                it.printStackTrace()
-                return
-            }
+            getMonsteraLogger("addon").error(it.message)
+            it.printStackTrace()
+            return
+        }
 
-            val conf2 = config("my_test")  {
-                namespace = "monstera"
-                projectShort = "te"
-            }
+        val conf2 = config("my_test") {
+            namespace = "monstera"
+            projectShort = "te"
+        }
 
-            addon(
+        addon(
             conf1
-            ) {
-                entity("my_test_entity", "My Test Entity") {
-                    behaviour {
-                        components {
-                            physics {  }
-                            pushable {  }
+        ) {
+            entity("my_test_entity", "My Test Entity") {
+                behaviour {
+                    components {
+                        physics { }
+                        pushable { }
+                    }
+                    properties {
+                        enum("1rwong_start") {
+                            default("abc")
+                            values = mutableListOf("abc", "ab")
                         }
-                        properties {
-                            enum("1rwong_start") {
-                                default("abc")
-                                values = mutableListOf("abc", "ab")
-                            }
-                            enum("missing_default") {
-                                values = mutableListOf("a")
-                            }
-                            enum("missing_values") {
-                                default("ab")
-                            }
+                        enum("missing_default") {
+                            values = mutableListOf("a")
                         }
-
-                        craftingRecipe {
-
+                        enum("missing_values") {
+                            default("ab")
                         }
                     }
-                    resource {
-                        components {
-                            spawnEgg("Spawn $name") {
-                                eggByColor(Color.CYAN, Color.BLACK)
-                            }
-                        }
+
+                    craftingRecipe {
+
                     }
                 }
-                entity("aververyverlongnametahtisshurlytoolongthanks") {
-
-                }
-                item("my_item", "My Item") {
-
+                resource {
+                    components {
+                        spawnEgg("Spawn $name") {
+                            eggByColor(Color.CYAN, Color.BLACK)
+                        }
+                    }
                 }
             }
+            entity("aververyverlongnametahtisshurlytoolongthanks") {
+
+            }
+            item("my_item", "My Item") {
+
+            }
+        }
     }
 }

--- a/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/Integration.kt
@@ -1,13 +1,24 @@
 package com.lop.devtools.monstera
 
 import com.lop.devtools.monstera.addon.addon
+import com.lop.devtools.monstera.files.getResource
 import java.awt.Color
 
 fun main() {
-    addon(config("testPrj") {
-        description = "This is a Test Project"
-        //packIcon = getResource("pack.png")
-    }) {
+    val conf1 = loadConfig(getResource("monstera.json"), getResource("monstera-local.json")).getOrElse {
+        getMonsteraLogger("addon").error(it.message)
+        it.printStackTrace()
+        return
+    }
+
+    val conf2 = config("my_test")  {
+        namespace = "monstera"
+        projectShort = "te"
+    }
+
+    addon(
+       conf2
+    ) {
         entity("my_test_entity", "My Test Entity") {
             behaviour {
                 components {

--- a/src/test/kotlin/com/lop/devtools/monstera/addon/entitiy/AnimControllerTest.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/addon/entitiy/AnimControllerTest.kt
@@ -19,6 +19,7 @@ class AnimControllerTest {
     @OptIn(MonsteraExperimental::class)
     @Test
     fun basicAnimControllerTest() = testAddon {
+        buildToMcFolder = true
         entity("my_anim_test", "Anim Test") {
             behaviour {
                 components {

--- a/src/test/kotlin/com/lop/devtools/monstera/files/DeserializerTest.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/files/DeserializerTest.kt
@@ -19,7 +19,21 @@ class DeserializerTest {
         myClass.additionalKeys = mapOf("key1" to "value1", "key2" to "value2")
         myClass.clazzInner.additionalKeys = mapOf("key1" to "value1", "key2" to "value2")
 
-        val json = gson.toJson(myClass, MonsteraRawFile::class.java)
+        var json = gson.toJson(myClass, MonsteraRawFile::class.java)
+        println(json)
+
+        myClass.mapTest = mutableMapOf("my_map_test" to MyClass2().apply {
+            additionalKeys = mapOf("mapInner" to "check")
+        })
+
+        json = gson.toJson(myClass, MonsteraRawFile::class.java)
+        println(json)
+
+        myClass.listTest = mutableListOf(MyClass2().apply {
+            additionalKeys = mapOf("listInner" to "check")
+        })
+
+        json = gson.toJson(myClass, MonsteraRawFile::class.java)
         println(json)
     }
 
@@ -30,6 +44,14 @@ class DeserializerTest {
         @Expose
         @JsonAdapter(MonsteraRawFileTypeAdapter::class)
         var clazzInner = MyClass2()
+
+        @Expose
+        @JsonAdapter(MonsteraMapFileTypeAdapter::class)
+        var mapTest: MutableMap<String, MyClass2>? = null
+
+        @Expose
+        @JsonAdapter(MonsteraListFileTypeAdapter::class)
+        var listTest: MutableList<MyClass2>? = null
     }
 
     class MyClass2 : MonsteraRawFile() {

--- a/src/test/resources/monstera-local.json
+++ b/src/test/resources/monstera-local.json
@@ -1,0 +1,4 @@
+{
+    "projectPath": "",
+    "buildPath": "build"
+}

--- a/src/test/resources/monstera.json
+++ b/src/test/resources/monstera.json
@@ -1,0 +1,69 @@
+{
+    "name": "Test Project",
+    "projectShort": "tpr",
+    "description": "My test Project",
+    "namespace": "monstera",
+    "version": [
+        0,
+        0,
+        1
+    ],
+    "authors": [
+        "Matthias Klenz"
+    ],
+    "worldUUID": "fe8b47f7-dfe9-4ad1-ac1f-18b8fda6bba6",
+    "worldModuleUUID": "8ac9af62-3bcd-4ebc-9600-a53ba72378fa",
+    "behUUID": "01ad7aa7-917a-45d4-8678-29dce3d36e05",
+    "behModuleUUID": "f60f5b8c-f5ff-4648-b069-e0554531b3df",
+    "scriptUUID": "a7966416-236e-4da7-a7e6-fe3f13ab8c79",
+    "resUUID": "c9a9728b-af73-4251-bcea-e4df4371f309",
+    "resModuleUUID": "41b5e80e-b651-46a7-a3c1-f3d829020ef0",
+    "targetMcVersion": [
+        1,
+        20,
+        70
+    ],
+    "scriptingVersion": "1.8.0",
+    "minecraftPaths": {
+        "behEntity": "entities",
+        "behAnimController": "animation_controllers",
+        "behAnim": "animations",
+        "behBlocks": "blocks",
+        "behItems": "items",
+        "lootTableEntity": "loot_tables/entities",
+        "lootTableBlock": "loot_tables/blocks",
+        "behSpawnRules": "spawn_rules",
+        "behTrading": "trading/economy_trades",
+        "behRecipes": "recipes",
+        "behTexts": "texts",
+        "behScripts": "scripts",
+        "behMcFunction": "functions",
+        "resAnim": "animations",
+        "resAnimController": "animation_controllers",
+        "resEntity": "entity",
+        "resItem": "items",
+        "resModels": "models",
+        "resMaterials": "materials",
+        "resParticles": "particles",
+        "resRenderControllers": "render_controllers",
+        "resSounds": "sounds",
+        "resTextures": "textures",
+        "resAttachable": "attachables",
+        "resTexts": "texts"
+    },
+    "minecraftFormatVersions": {
+        "behEntitty": "1.20.70",
+        "behItem": "1.10.0",
+        "behAnim": "1.8.0",
+        "behBlock": "1.20.70",
+        "behRecipe": "1.17.41",
+        "behSpawnRule": "1.8.0",
+        "behAnimController": "1.10.0",
+        "resEntity": "1.10.0",
+        "resItem": "1.10.0",
+        "resAnimController": "1.10.0",
+        "resAttachable": "1.10.0",
+        "resSoundDefs": "1.14.0",
+        "resRenderController": "1.10.0"
+    }
+}

--- a/src/test/resources/monstera.json
+++ b/src/test/resources/monstera.json
@@ -26,6 +26,7 @@
     ],
     "scriptingVersion": "1.8.0",
     "packIcon": "src/main/resources/pack.png",
+    "hashFileNames": true,
     "minecraftPaths": {
         "behEntity": "entities",
         "behAnimController": "animation_controllers",

--- a/src/test/resources/monstera.json
+++ b/src/test/resources/monstera.json
@@ -11,6 +11,7 @@
     "authors": [
         "Matthias Klenz"
     ],
+    "world": "src/main/resources/template-wrold",
     "worldUUID": "fe8b47f7-dfe9-4ad1-ac1f-18b8fda6bba6",
     "worldModuleUUID": "8ac9af62-3bcd-4ebc-9600-a53ba72378fa",
     "behUUID": "01ad7aa7-917a-45d4-8678-29dce3d36e05",
@@ -24,6 +25,7 @@
         70
     ],
     "scriptingVersion": "1.8.0",
+    "packIcon": "src/main/resources/pack.png",
     "minecraftPaths": {
         "behEntity": "entities",
         "behAnimController": "animation_controllers",


### PR DESCRIPTION
Previously, it was only possible to insert keys into objects that were not in a map or list.

```kotlin
components {
     additionalKeys = mapOf("my_component" to "my_value")
}
```

This is now also possible in component groups for example

```kotlin
componentGroup("my_component_group") {
     additionalKeys = mapOf("my_component" to "my_value")
}
```

+ added 2 new JsonSerializer for `Map<String, MonsteraRawFile>` and `List<MonsteraRawFile>`
+ added these serializers to all components, spawn rules, loot tables, items, sounds