### PR TITLE
add namespace to controllers + anims

### DIFF
--- a/.fleet/run.json
+++ b/.fleet/run.json
@@ -1,0 +1,10 @@
+{
+    "configurations": [
+        {
+            "type": "gradle",
+            "name": "Gradle Test",
+            "tasks": ["test"],
+        },
+        
+    ]
+}

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/entity/behaviour/BehaviourEntityImpl.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/entity/behaviour/BehaviourEntityImpl.kt
@@ -46,7 +46,7 @@ open class BehaviourEntity(val entityData: Entity.Data) : OverwriteComponents(en
      * add a behaviour animation
      *
      * ```
-     * animation {
+     * animation("walk") {
      *      timeline {
      *
      *      }
@@ -55,7 +55,7 @@ open class BehaviourEntity(val entityData: Entity.Data) : OverwriteComponents(en
      * ```
      */
     open fun animation(name: String, settings: BehAnimation.() -> Unit) {
-        unsafeRawAnimations.animation("animation.${entityData.name}.$name", settings)
+        unsafeRawAnimations.animation("animation.${entityData.addon.config.namespace}.${entityData.name}.$name", settings)
         addSharedAnimation("animation.${entityData.name}.$name", name)
     }
 
@@ -89,7 +89,7 @@ open class BehaviourEntity(val entityData: Entity.Data) : OverwriteComponents(en
      * @param from the original entity where the animation was defined
      */
     open fun addSharedAnimation(originalName: String, localName: String = originalName, from: Entity) {
-        addSharedAnimation("animation.${from.name}.$originalName", localName)
+        addSharedAnimation("animation.${entityData.addon.config.namespace}.${from.name}.$originalName", localName)
     }
 
     /**
@@ -108,7 +108,7 @@ open class BehaviourEntity(val entityData: Entity.Data) : OverwriteComponents(en
      * @param data the controller
      */
     open fun animController(name: String, query: Molang = Query.True, data: AnimationControllers.Controller.() -> Unit) {
-        val id = "controller.animation.${entityData.name}.$name"
+        val id = "controller.animation.${entityData.addon.config.namespace}.${entityData.name}.$name"
         unsafeRawControllers.animController(id, data)
         addSharedController(id, query, name)
     }
@@ -142,7 +142,7 @@ open class BehaviourEntity(val entityData: Entity.Data) : OverwriteComponents(en
      * @param query when the controller should be active - optional, default always
      */
     open fun addSharedController(originalName: String, localName: String = originalName, from: Entity, query: Molang) {
-        addSharedController("controller.animation.${from.name}.$originalName", query, localName)
+        addSharedController("controller.animation.${entityData.addon.config.namespace}.${from.name}.$originalName", query, localName)
     }
 
     /**

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/entity/resource/RenderPart.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/entity/resource/RenderPart.kt
@@ -302,7 +302,7 @@ open class RenderPart(val partName: String, query: Molang, val entityData: Entit
                 )
             } else {
                 unsafeRenderController.apply {
-                    controllers("${entityData.name}.$partName") {
+                    controllers("${entityData.addon.config.namespace}.${entityData.name}.$partName") {
                         texture("Texture.default")
                     }
                 }
@@ -313,7 +313,7 @@ open class RenderPart(val partName: String, query: Molang, val entityData: Entit
                 materials.forEach { (bone, material) ->
                     this@description.material(materialEntityId(bone), material)
                 }
-                renderController("controller.render.${entityData.name}.$partName", Query(query))
+                renderController("controller.render.${entityData.addon.config.namespace}.${entityData.name}.$partName", Query(query))
             }
         }
     }

--- a/src/main/kotlin/com/lop/devtools/monstera/addon/entity/resource/ResourceEntity.kt
+++ b/src/main/kotlin/com/lop/devtools/monstera/addon/entity/resource/ResourceEntity.kt
@@ -270,7 +270,7 @@ open class ResourceEntity(val entityData: Entity.Data) {
         query: Molang = Query.True,
         data: AnimationControllers.Controller.() -> Unit
     ) {
-        val idName = "controller.animation.${entityData.name}.${name.removePrefix("controller.animation.")}"
+        val idName = "controller.animation.${entityData.addon.config.namespace}.${entityData.name}.${name.removePrefix("controller.animation.")}"
         unsafeControllers.animController(idName, data)
 
         unsafeRawEntity.apply {

--- a/src/test/kotlin/com/lop/devtools/monstera/addon/entitiy/AnimControllerTest.kt
+++ b/src/test/kotlin/com/lop/devtools/monstera/addon/entitiy/AnimControllerTest.kt
@@ -54,7 +54,7 @@ class AnimControllerTest {
             assert(
                 containsKeyChain(
                     "animation_controllers",
-                    "controller.animation.my_anim_test.my_anim_controller",
+                    "controller.animation.${config.namespace}.my_anim_test.my_anim_controller",
                     "initial_state"
                 )
             )
@@ -62,7 +62,7 @@ class AnimControllerTest {
                 containsKeyChainValue(
                     value = "(variable.my_var == 0)",
                     "animation_controllers",
-                    "controller.animation.my_anim_test.my_anim_controller",
+                    "controller.animation.${config.namespace}.my_anim_test.my_anim_controller",
                     "states",
                     "default",
                     "transitions",
@@ -72,7 +72,7 @@ class AnimControllerTest {
             assert(
                 containsKeyChain(
                     "animation_controllers",
-                    "controller.animation.my_anim_test.my_anim_controller",
+                    "controller.animation.${config.namespace}.my_anim_test.my_anim_controller",
                     "states",
                     "success",
                     "on_entry"


### PR DESCRIPTION
closes #116

- possible breaking change in the behaviour entity functions
```kotlin
addSharedAnimation(originalName: String, localName: String = originalName, from: Entity)
addSharedController(originalName: String, localName: String = originalName, from: Entity, query: Molang)
``` 
due to an ambiguous change in the parsing of the anim controller identifier, which now includes the namespace. This change has no effect if the default controller function was used to create the controller in the original entity.
